### PR TITLE
Move tf-controller chart

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,16 @@
+name: helm-release
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write # needed to push chart
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,51 @@
+name: helm-test
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'charts/tf-controller/**'
+      - '.github/workflows/helm-test.yaml'
+
+permissions: read-all
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: 3.*
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,3 +82,7 @@ jobs:
           body: |
             [CHANGELOG](https://github.com/weaveworks/${{ env.CONTROLLER }}/blob/main/CHANGELOG.md)
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After that you can install TF-controller manually with Helm by:
 
 ```shell
 # Add tf-controller helm repository to local
-helm repo add tf-controller https://tf-controller.github.io/charts/
+helm repo add tf-controller https://weaveworks.github.io/tf-controller/
 
 # Install tf-controller
 helm upgrade -i tf-controller tf-controller/tf-controller \
@@ -58,7 +58,7 @@ helm upgrade -i tf-controller tf-controller/tf-controller \
 ```
 
 For details on configurable parameters of the TF-controller chart,
-please see [chart readme](https://github.com/tf-controller/charts/blob/main/charts/tf-controller/README.md).
+please see [chart readme](./charts/tf-controller/README.md).
 
 Alternatively, you can install TF-controller via `kubectl`:
 

--- a/charts/tf-controller/.helmignore
+++ b/charts/tf-controller/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+README.md

--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tf-controller
+description: A Helm chart for TF-controller
+type: application
+version: 0.0.5
+appVersion: "0.8.0"

--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: A Helm chart for TF-controller
 type: application
-version: 0.0.5
+version: 0.1.0
 appVersion: "0.8.0"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -1,0 +1,34 @@
+# TF-controller for Flux
+
+A Helm chart for TF-controller
+
+## Installation
+
+Before using TF-controller, you have to install Flux by using either `flux install` or `flux bootstrap` command.
+
+## Configuration
+
+The following tables lists the configurable parameters of the TF-controller chart and their default values.
+
+| Parameter                                         | Default                                              | Description
+| -----------------------------------------------   | ---------------------------------------------------- | ---
+| `image.repository`                                | `ghcr.io/chanwit/tf-controller`                      | Image repository
+| `image.tag`                                       | `<VERSION>`                                          | Image tag
+| `image.pullPolicy`                                | `IfNotPresent`                                       | Image pull policy
+| `image.pullSecret`                                | `None`                                               | Image pull secret
+| `installCRDs`                                     | `true`                                               | If `true`, install CRDs as part of the helm installation
+| `replicaCount`                                    | `1`                                                  | Number of TF-Controller pods to deploy, more than one is not desirable.
+| `resources.requests.cpu`                          | `200m`                                               | CPU resource requests for the TF-Controller deployment
+| `resources.requests.memory`                       | `64Mi`                                               | Memory resource requests for the TF-Controller deployment
+| `resources.limits.cpu`                            | `1000m`                                              | CPU/memory resource limits for the TF-Controller deployment
+| `resources.limits.memory`                         | `1Gi`                                                | CPU/memory resource limits for the TF-Controller deployment
+| `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the TF-Controller deployment
+| `tolerations`                                     | `[]`                                                 | Tolerations properties for the TF-Controller deployment
+| `affinity`                                        | `{}`                                                 | Affinity properties for the TF-Controller deployment
+| `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
+| `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
+| `serviceAccount.name`                             | `tf-controller`                                      | Service account to be used
+| `serviceAccount.annotations`                      | ``                                                   | Additional Service Account annotations
+| `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
+| `podSecurityContext`                              | `{}`                                                 | Pod security context configurations
+| `securityContext`                                 | `{}`                                                 | Container security context configurations

--- a/charts/tf-controller/templates/_helpers.tpl
+++ b/charts/tf-controller/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tf-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tf-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tf-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tf-controller.labels" -}}
+helm.sh/chart: {{ include "tf-controller.chart" . }}
+{{ include "tf-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+control-plane: controller
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tf-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tf-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tf-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tf-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/tf-controller/templates/crds.yaml
+++ b/charts/tf-controller/templates/crds.yaml
@@ -1,0 +1,417 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  labels:
+    {{- include "tf-controller.labels" . | nindent 4 }}
+  name: terraforms.infra.contrib.fluxcd.io
+spec:
+  group: infra.contrib.fluxcd.io
+  names:
+    kind: Terraform
+    listKind: TerraformList
+    plural: terraforms
+    shortNames:
+    - tf
+    singular: terraform
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Terraform is the Schema for the terraforms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TerraformSpec defines the desired state of Terraform
+            properties:
+              approvePlan:
+                description: ApprovePlan specifies name of a plan wanted to approve.
+                  If its value is "auto", the controller will automatically approve
+                  every plan.
+                type: string
+              backendConfig:
+                description: BackendConfigSpec is for specifying configuration for
+                  Terraform's Kubernetes backend
+                properties:
+                  configPath:
+                    type: string
+                  disable:
+                    description: Disable is to completely disable the backend configuration.
+                    type: boolean
+                  inClusterConfig:
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  secretSuffix:
+                    type: string
+                type: object
+              cliConfigSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              destroy:
+                description: Destroy produces a destroy plan. Applying the plan will
+                  destroy all resources.
+                type: boolean
+              disableDriftDetection:
+                default: false
+                description: Disable automatic drift detection. Drift detection may
+                  be resource intensive in the context of a large cluster or complex
+                  Terraform statefile. Defaults to false.
+                type: boolean
+              force:
+                default: false
+                description: Force instructs the controller to unconditionally re-plan
+                  and re-apply TF resources. Defaults to false.
+                type: boolean
+              interval:
+                description: The interval at which to reconcile the Terraform.
+                type: string
+              path:
+                description: Path to the directory containing Terraform (.tf) files.
+                  Defaults to 'None', which translates to the root path of the SourceRef.
+                type: string
+              retryInterval:
+                description: The interval at which to retry a previously failed reconciliation.
+                  When not specified, the controller uses the TerraformSpec.Interval
+                  value to retry failures.
+                type: string
+              sourceRef:
+                description: SourceRef is the reference of the source where the Terraform
+                  files are stored.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, defaults to the namespace
+                      of the Kubernetes resource object that contains the reference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: Suspend is to tell the controller to suspend subsequent
+                  TF executions, it does not apply to already started executions.
+                  Defaults to false.
+                type: boolean
+              vars:
+                description: List of input variables to set for the Terraform program.
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of the variable
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      description: EnvVarSource represents a source for the value
+                        of an EnvVar.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              varsFrom:
+                description: List of references to a Secret or a ConfigMap to generate
+                  variables for Terraform resources based on its data, selectively
+                  by varsKey. Values of the later Secret / ConfigMap with the samek
+                  keys will override those of the former.
+                items:
+                  description: VarsReference contain a reference of a Secret or a
+                    ConfigMap to generate variables for Terraform resources based
+                    on its data, selectively by varsKey.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the values referent. Should reside in the
+                        same namespace as the referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: Optional marks this VarsReference as optional.
+                        When set, a not found error for the values reference is ignored,
+                        but any VarsKey or transient error will still result in a
+                        reconciliation failure.
+                      type: boolean
+                    varsKeys:
+                      description: VarsKeys is the data key where the values.yaml
+                        or a specific value can be found at. Defaults to all keys.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              writeOutputsToSecret:
+                description: A list of target secrets for the outputs to be written
+                  as.
+                properties:
+                  name:
+                    description: Name is the name of the Secret to be written
+                    type: string
+                  outputs:
+                    description: Outputs contain the selected names of outputs to
+                      be written to the secret. Empty array means writing all outputs,
+                      which is default.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - name
+                type: object
+            required:
+            - interval
+            - sourceRef
+            type: object
+          status:
+            description: TerraformStatus defines the observed state of Terraform
+            properties:
+              availableOutputs:
+                items:
+                  type: string
+                type: array
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAppliedRevision:
+                description: The last successfully applied revision. The revision
+                  format for Git sources is <branch|tag>/<commit-sha>.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change can be detected.
+                type: string
+              lastPlannedRevision:
+                description: LastPlannedRevision is the revision used by the last
+                  planning process. The result could be either no plan change or a
+                  new plan generated.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
+              plan:
+                properties:
+                  isDestroyPlan:
+                    type: boolean
+                  lastApplied:
+                    type: string
+                  pending:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/tf-controller/templates/deployment.yaml
+++ b/charts/tf-controller/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "tf-controller.labels" . | nindent 4 }}
+  name: {{ include "tf-controller.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tf-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tf-controller.selectorLabels" . | nindent 10 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - args:
+        - --watch-all-namespaces
+        - --log-level=info
+        - --log-encoding=json
+        - --enable-leader-election
+        - --concurrent=1
+        command:
+        - /sbin/tini
+        - --
+        - tf-controller
+        env:
+        - name: RUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: {{ .Chart.Name }}
+        ports:
+        - containerPort: 8080
+          name: http-prom
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: temp
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "tf-controller.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: temp
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tf-controller/templates/rbac.yaml
+++ b/charts/tf-controller/templates/rbac.yaml
@@ -1,0 +1,154 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tf-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tf-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - infra.contrib.fluxcd.io
+  resources:
+  - terraforms
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infra.contrib.fluxcd.io
+  resources:
+  - terraforms/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infra.contrib.fluxcd.io
+  resources:
+  - terraforms/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - gitrepositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets/status
+  - gitrepositories/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tf-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tf-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tf-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tf-cluster-reconciler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tf-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tf-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tf-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tf-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/tf-controller/templates/serviceaccount.yaml
+++ b/charts/tf-controller/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tf-controller.serviceAccountName" . }}
+  labels:
+    {{- include "tf-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -1,0 +1,48 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/chanwit/tf-controller
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.8.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+installCRDs: true
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 1337
+
+securityContext: {}
+  # allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: true
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 200m
+    memory: 64Mi
+
+rbac:
+  create: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+validate-maintainers: false


### PR DESCRIPTION
- move tf-controller chart from https://github.com/tf-controller/charts
- add chart test action
- add chart release action
- add chart as part of release step

Resolves https://github.com/weaveworks/tf-controller/issues/86

The release action pushes index.yaml and chart package to `gh-pages` branch. This requires github pages to be set up have the helm repository accessible. An issue is submitted to the organization admin. 

Signed-off-by: Tom Huang <tom.huang@weave.works>