### PR TITLE
Fix e2e make targets and issues uncovered

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,6 +83,10 @@ jobs:
           make dev-deploy IMG=test/tf-controller:latest
           kubectl -n tf-system rollout status deploy/source-controller --timeout=1m
           kubectl -n tf-system rollout status deploy/tf-controller --timeout=1m
+      - name: Get terraform version
+        run: |
+          POD=$(kubectl get pod -l control-plane=tf-controller -n tf-system -o jsonpath="{.items[0].metadata.name}")
+          kubectl exec -n tf-system $POD -- terraform version
       - name: Add git repository source
         run: |
           kubectl -n tf-system apply -f ./config/testdata/source

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
           fi
       - name: Build container image
         run: |
-          make docker-build IMG=test/tf-controller:latest \
+          make docker-build IMG=test/tf-controller TAG=latest \
             BUILD_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache \
               --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
               --load"
@@ -80,7 +80,7 @@ jobs:
         run: make install
       - name: Deploy controllers
         run: |
-          make dev-deploy IMG=test/tf-controller:latest
+          make dev-deploy IMG=test/tf-controller TAG=latest
           kubectl -n tf-system rollout status deploy/source-controller --timeout=1m
           kubectl -n tf-system rollout status deploy/tf-controller --timeout=1m
       - name: Get terraform version

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,3 +57,38 @@ Run the controller locally:
 make install
 make run
 ```
+
+## How to install the controller
+
+### Building the container image
+
+Set the name of the container image to be created from the source code. This will be used when building, pushing and referring to the image on YAML files:
+
+```sh
+export IMG=registry-path/tf-controller:latest
+```
+
+Build the container image, tagging it as `$IMG`:
+
+```sh
+make docker-build
+```
+
+Push the image into the repository:
+
+```sh
+make docker-push
+```
+
+**Note**: `make docker-build` will build an image for the `amd64` architecture.
+
+
+### Deploying into a cluster
+
+Deploy `tf-controller` into the cluster that is configured in the local kubeconfig file (i.e. `~/.kube/config`):
+
+```sh
+make deploy
+```
+
+Running the above will also deploy `source-controller` and its CRDs to the cluster.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/weaveworks/tf-controller
-TAG ?= latest
+IMG ?= ghcr.io/weaveworks/tf-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 # source controller version
@@ -100,7 +99,7 @@ docker-build: ## Build docker
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}:${TAG}
+	docker push ${IMG}
 
 ##@ Deployment
 
@@ -118,7 +117,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image weaveworks/tf-controller=${IMG}:${TAG}
+	cd config/manager && $(KUSTOMIZE) edit set image weaveworks/tf-controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
@@ -129,7 +128,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 .PHONY: dev-deploy
 dev-deploy: manifests kustomize
 	mkdir -p config/dev && cp config/default/* config/dev
-	cd config/dev && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}
 	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 	rm -rf config/dev
 
@@ -137,7 +136,7 @@ dev-deploy: manifests kustomize
 .PHONY: dev-cleanup
 dev-cleanup: manifests kustomize
 	mkdir -p config/dev && cp config/default/* config/dev
-	cd config/dev && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}
 	$(KUSTOMIZE) build config/dev | kubectl delete -f -
 	rm -rf config/dev
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/weaveworks/tf-controller:latest
+IMG ?= ghcr.io/weaveworks/tf-controller
+TAG ?= latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 # source controller version
@@ -95,11 +96,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker
-	docker buildx build -t ${IMG} ${BUILD_ARGS} .
+	docker buildx build -t ${IMG}:${TAG} ${BUILD_ARGS} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push ${IMG}:${TAG}
 
 ##@ Deployment
 
@@ -117,7 +118,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image weaveworks/tf-controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image weaveworks/tf-controller=${IMG}:${TAG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
@@ -128,7 +129,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 .PHONY: dev-deploy
 dev-deploy: manifests kustomize
 	mkdir -p config/dev && cp config/default/* config/dev
-	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}
+	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}:${TAG}
 	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 	rm -rf config/dev
 
@@ -136,7 +137,7 @@ dev-deploy: manifests kustomize
 .PHONY: dev-cleanup
 dev-cleanup: manifests kustomize
 	mkdir -p config/dev && cp config/default/* config/dev
-	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}
+	cd config/dev && $(KUSTOMIZE) edit set image ghcr.io/weaveworks/tf-controller=${IMG}:${TAG}
 	$(KUSTOMIZE) build config/dev | kubectl delete -f -
 	rm -rf config/dev
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	crtlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	//+kubebuilder:scaffold:imports
 )
@@ -132,6 +133,16 @@ func main() {
 	}
 
 	//+kubebuilder:scaffold:builder
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
 	ctx := ctrl.SetupSignalHandler()
 
 	certsReady := make(chan struct{})

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -104,9 +104,11 @@ func main() {
 	metricsRecorder := metrics.NewRecorder()
 	crtlmetrics.Registry.MustRegister(metricsRecorder.Collectors()...)
 
+	runtimeNamespace := os.Getenv("RUNTIME_NAMESPACE")
+
 	watchNamespace := ""
 	if !watchAllNamespaces {
-		watchNamespace = os.Getenv("RUNTIME_NAMESPACE")
+		watchNamespace = runtimeNamespace
 	}
 
 	restConfig := client.GetConfigOrDie(clientOptions)
@@ -139,7 +141,7 @@ func main() {
 		CAOrganization: "weaveworks",
 		DNSName:        "tf-controller",
 		SecretKey: types.NamespacedName{
-			Namespace: "flux-system",
+			Namespace: runtimeNamespace,
 			Name:      "tf-controller.tls",
 		},
 		Ready: certsReady,

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
       containers:
       - name: manager
         image: weaveworks/tf-controller
+        imagePullPolicy: IfNotPresent
         command:
         - /sbin/tini
         - --


### PR DESCRIPTION
While debugging, I found that the make targets used by e2e test were not using the latest image built. After fixing them, I uncovered two issues that weren't previously discovered. These issues are fixed in this PR. 
- The mtls certificate secret was using `flux-system` as its namespace. This could be problematic if the user does not have `flux-system` namespace and want to install in another namespace. This caused the controller in CrashLoopBackOff state with the following error.
```
{"level":"error","ts":"2022-02-10T21:22:23.106Z","logger":"setup","msg":"problem running manager","error":"creating secret to update certificates: namespaces \"flux-system\" not found","errorVerbose":"namespaces \"flux-system\" not found\ncreating secret to update certificates\ngithub.com/weaveworks/tf-controller/mtls.(*CertRotator).refreshCertIfNeeded.func1\n\t/workspace/mtls/rotator.go:128\nk8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.23.1/pkg/util/wait/wait.go:220\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.23.1/pkg/util/wait/wait.go:233\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/go/pkg/mod/k8s.io/apimachinery@v0.23.1/pkg/util/wait/wait.go:226\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/go/pkg/mod/k8s.io/apimachinery@v0.23.1/pkg/util/wait/wait.go:421\ngithub.com/weaveworks/tf-controller/mtls.(*CertRotator).refreshCertIfNeeded\n\t/workspace/mtls/rotator.go:160\ngithub.com/weaveworks/tf-controller/mtls.(*CertRotator).Start\n\t/workspace/mtls/rotator.go:90\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/manager/runnable_group.go:218\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581"}
```

- The liveness and readiness probe health check endpoints were previously removed, causing the controller not becoming ready. @phoban01 please correct me if there was a reason those have been removed and what the correct fix should be.

This PR also adds outputting terraform version in the e2e flow.

Fix: https://github.com/weaveworks/tf-controller/issues/91