### PR TITLE
Add .spec.destroyResourcesOnDeletion

### DIFF
--- a/api/v1alpha1/terraform_types.go
+++ b/api/v1alpha1/terraform_types.go
@@ -137,6 +137,12 @@ type TerraformSpec struct {
 	// List of health checks to be performed.
 	// +optional
 	HealthChecks []HealthCheck `json:"healthChecks,omitempty"`
+
+	// Create destroy plan and apply it to destroy terraform resources
+	// upon deletion of this object. Defaults to false.
+	// +kubebuilder:default:=false
+	// +optional
+	DestroyResourcesOnDeletion bool `json:"destroyResourcesOnDeletion,omitempty"`
 }
 
 type PlanStatus struct {

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -88,6 +88,11 @@ spec:
                 description: Destroy produces a destroy plan. Applying the plan will
                   destroy all resources.
                 type: boolean
+              destroyResourcesOnDeletion:
+                default: false
+                description: Create destroy plan and apply it to destroy terraform
+                  resources upon deletion of this object. Defaults to false.
+                type: boolean
               disableDriftDetection:
                 default: false
                 description: Disable automatic drift detection. Drift detection may

--- a/controllers/tc000121_destroy_on_delete_test.go
+++ b/controllers/tc000121_destroy_on_delete_test.go
@@ -1,0 +1,328 @@
+package controllers
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	. "github.com/onsi/gomega"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha1"
+	"github.com/weaveworks/tf-controller/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+func Test_000121_destroy_on_delete_test(t *testing.T) {
+	Spec("Terraform object with destroyResourcesOnDeletion should destroy all resources after object deletion.")
+
+	// when("creating a Terraform object with the auto approve mode, and having a GitRepository attached to it.")
+	It("should obtain the TF program's blob from the Source, unpack it, plan it, and apply it correctly with an output available, and there must be *NO* tfstate Secret because no backend specified.")
+	const (
+		sourceName    = "test-tf-controller-destroy-on-delete"
+		terraformName = "tf-destroy-on-delete"
+	)
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	Given("a GitRepository")
+	By("defining a new GitRepository object")
+	testRepo := sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceName,
+			Namespace: "flux-system",
+		},
+		Spec: sourcev1.GitRepositorySpec{
+			URL: "https://github.com/openshift-fluxv2-poc/podinfo",
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "master",
+			},
+			Interval:          metav1.Duration{Duration: time.Second * 30},
+			GitImplementation: "go-git",
+		},
+	}
+	By("creating the GitRepository object")
+	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
+	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+
+	Given("that the GitRepository got reconciled")
+	By("setting the GitRepository's status, with the BLOB's URL, and the correct checksum")
+	updatedTime := time.Now()
+	testRepo.Status = sourcev1.GitRepositoryStatus{
+		ObservedGeneration: int64(1),
+		Conditions: []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: updatedTime},
+				Reason:             "GitOperationSucceed",
+				Message:            "Fetched revision: master/b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+			},
+		},
+		URL: server.URL() + "/tf-k8s-configmap.tar.gz",
+		Artifact: &sourcev1.Artifact{
+			Path:           "gitrepository/flux-system/test-tf-controller/b8e362c206e3d0cbb7ed22ced771a0056455a2fb.tar.gz",
+			URL:            server.URL() + "/tf-k8s-configmap.tar.gz",
+			Revision:       "master/b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+			Checksum:       "c3bf30bad9621b5110a3761a70754170d1dae6c525a63098b6ec9919efac3555", // must be the real checksum value
+			LastUpdateTime: metav1.Time{Time: updatedTime},
+		},
+	}
+	g.Expect(k8sClient.Status().Update(ctx, &testRepo)).Should(Succeed())
+
+	testEnvKubeConfigPath, err := findKubeConfig(testEnv)
+	g.Expect(err).Should(BeNil())
+
+	Given("a Terraform object with auto approve, and attaching it to the GitRepository object")
+	By("creating a new TF resource and attaching to the repo via sourceRef")
+	helloWorldTF := infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      terraformName,
+			Namespace: "flux-system",
+		},
+		Spec: infrav1.TerraformSpec{
+			BackendConfig: &infrav1.BackendConfigSpec{
+				SecretSuffix:    terraformName,
+				InClusterConfig: false,
+				ConfigPath:      testEnvKubeConfigPath,
+			},
+			ApprovePlan:                "auto",
+			DestroyResourcesOnDeletion: true,
+			Path:                       "./tf-k8s-configmap",
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Kind:      "GitRepository",
+				Name:      sourceName,
+				Namespace: "flux-system",
+			},
+			Vars: []infrav1.Variable{
+				{
+					Name:  "kubeconfig",
+					Value: utils.JsonEncodeBytes([]byte(testEnvKubeConfigPath)),
+				},
+				{
+					Name:  "context",
+					Value: utils.JsonEncodeBytes([]byte("envtest")),
+				},
+				{
+					Name:  "config_name",
+					Value: utils.JsonEncodeBytes([]byte("cm-" + terraformName)),
+				},
+			},
+		},
+	}
+	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
+
+	It("should be created")
+	By("checking that the TF got created")
+	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}
+	createdHelloWorldTF := infrav1.Terraform{}
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return false
+		}
+		return true
+	}, timeout, interval).Should(BeTrue())
+
+	It("should have conditions reconciled")
+	By("checking that the TF's status conditions has some elements")
+	g.Eventually(func() int {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return -1
+		}
+		return len(createdHelloWorldTF.Status.Conditions)
+	}, timeout, interval).ShouldNot(BeZero())
+
+	It("should have its plan reconciled")
+	By("checking that the Plan's Status of the TF program is Planned Succeed.")
+	g.Eventually(func() interface{} {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return nil
+		}
+		for _, c := range createdHelloWorldTF.Status.Conditions {
+			if c.Type == "Plan" {
+				return map[string]interface{}{
+					"Type":    c.Type,
+					"Reason":  c.Reason,
+					"Message": c.Message,
+				}
+			}
+		}
+		return createdHelloWorldTF.Status
+	}, timeout, interval).Should(Equal(map[string]interface{}{
+		"Type":    "Plan",
+		"Reason":  "TerraformPlannedWithChanges",
+		"Message": "Plan generated",
+	}))
+
+	It("should generate the Secret containing the plan named with branch and commit id")
+	By("checking that the Secret contains plan-master-b8e362c206 in its labels")
+	tfplanKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
+	tfplanSecret := corev1.Secret{}
+	g.Eventually(func() map[string]interface{} {
+		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
+		if err != nil {
+			return nil
+		}
+		return map[string]interface{}{
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
+		}
+	}, timeout, interval).Should(Equal(map[string]interface{}{
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
+	}))
+
+	By("checking that the applied status of the TF program Successfully, and plan-master-b8e3 is applied")
+	g.Eventually(func() map[string]interface{} {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return nil
+		}
+		for _, c := range createdHelloWorldTF.Status.Conditions {
+			if c.Type == "Apply" {
+				return map[string]interface{}{
+					"Type":            c.Type,
+					"Reason":          c.Reason,
+					"Message":         c.Message,
+					"LastAppliedPlan": createdHelloWorldTF.Status.Plan.LastApplied,
+					"Destroy?":        createdHelloWorldTF.Status.Plan.IsDestroyPlan,
+				}
+			}
+		}
+		return nil
+	}, timeout, interval).Should(Equal(map[string]interface{}{
+		"Type":            "Apply",
+		"Reason":          infrav1.TFExecApplySucceedReason,
+		"Message":         "Applied successfully",
+		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Destroy?":        false,
+	}))
+
+	By("checking that we have outputs available in the TF object")
+	g.Eventually(func() []string {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return nil
+		}
+		return createdHelloWorldTF.Status.AvailableOutputs
+	}, timeout, interval).Should(Equal([]string{"api_host"}))
+
+	// We're testing out side Kubernetes
+	// so we have to disable in-cluster backend
+	if os.Getenv("DISABLE_TF_K8S_BACKEND") == "1" {
+		// So we're expecting that there must be no "tfstate-default-${terraformName}" secret
+		By("getting the tfstate and we should see it")
+		tfStateKey := types.NamespacedName{Namespace: "flux-system", Name: "tfstate-default-" + terraformName}
+		tfStateSecret := corev1.Secret{}
+		g.Eventually(func() string {
+			err := k8sClient.Get(ctx, tfStateKey, &tfStateSecret)
+			if err != nil {
+				return err.Error()
+			}
+			return tfStateSecret.Name
+		}, timeout, interval).Should(Equal("tfstate-default-tf-destroy-on-delete"))
+	} else {
+		// TODO there's must be the default tfstate secret
+	}
+
+	cmPayloadKey := types.NamespacedName{Namespace: "default", Name: "cm-" + terraformName}
+	var cmPayload corev1.ConfigMap
+	g.Eventually(func() string {
+		err := k8sClient.Get(ctx, cmPayloadKey, &cmPayload)
+		if err != nil {
+			return ""
+		}
+		return cmPayload.Name
+	}, timeout, interval).Should(Equal("cm-" + terraformName))
+
+	By("deleting TF object to trigger the destroy planning")
+	g.Expect(k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)).Should(Succeed())
+	g.Expect(k8sClient.Delete(ctx, &createdHelloWorldTF)).Should(Succeed())
+
+	It("should create the destroy plan, then apply")
+	g.Eventually(func() interface{} {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return nil
+		}
+		for _, c := range createdHelloWorldTF.Status.Conditions {
+			if c.Type == "Plan" {
+				return map[string]interface{}{
+					"Type":    c.Type,
+					"Reason":  c.Reason,
+					"Message": c.Message,
+				}
+			}
+		}
+		return createdHelloWorldTF.Status
+	}, timeout, interval).Should(Equal(map[string]interface{}{
+		"Type":    "Plan",
+		"Reason":  "TerraformPlannedWithChanges",
+		"Message": "Plan generated",
+	}))
+
+	By("checking that the Secret contains plan-master-b8e362c206 in its labels")
+	g.Eventually(func() map[string]interface{} {
+		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
+		if err != nil {
+			return nil
+		}
+		return map[string]interface{}{
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
+		}
+	}, timeout, interval).Should(Equal(map[string]interface{}{
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
+	}))
+
+	outputKey := types.NamespacedName{Namespace: "flux-system", Name: "tf-output-" + terraformName}
+	outputSecret := corev1.Secret{}
+	It("should destroy the output and the created resources")
+
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, outputKey, &outputSecret)
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		return false
+	}, timeout, interval).Should(BeTrue())
+
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, cmPayloadKey, &cmPayload)
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		return false
+	}, timeout, interval).Should(BeTrue())
+
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		return false
+	}, timeout, interval).Should(BeTrue())
+
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		return false
+	}, timeout, interval).Should(BeTrue())
+}

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -136,9 +136,12 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	defer closeConn()
 
+	// resolve source reference
+	sourceObj, err := r.getSource(ctx, terraform)
+
 	// Examine if the object is under deletion
 	if !terraform.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.finalize(ctx, terraform, runnerClient)
+		return r.finalize(ctx, terraform, runnerClient, sourceObj)
 	}
 
 	// Return early if the Terraform is suspended.
@@ -147,8 +150,6 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
-	// resolve source reference
-	sourceObj, err := r.getSource(ctx, terraform)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			msg := fmt.Sprintf("Source '%s' not found", terraform.Spec.SourceRef.String())
@@ -355,16 +356,16 @@ func (l LocalPrintfer) Printf(format string, v ...interface{}) {
 	l.logger.Info(fmt.Sprintf(format, v...))
 }
 
-func (r *TerraformReconciler) reconcile(ctx context.Context, runnerClient runner.RunnerClient, terraform infrav1.Terraform, sourceObj sourcev1.Source) (infrav1.Terraform, error) {
-
+func (r *TerraformReconciler) setupTerraform(ctx context.Context, runnerClient runner.RunnerClient, terraform infrav1.Terraform, sourceObj sourcev1.Source, revision string, objectKey types.NamespacedName) (infrav1.Terraform, string, string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	revision := sourceObj.GetArtifact().Revision
-	objectKey := types.NamespacedName{Namespace: terraform.Namespace, Name: terraform.Name}
+
+	tfInstance := "0"
+	tmpDir := ""
 
 	terraform = infrav1.TerraformProgressing(terraform, "Initializing")
 	if err := r.patchStatus(ctx, objectKey, terraform.Status); err != nil {
 		log.Error(err, "unable to update status before Terraform initialization")
-		return terraform, err
+		return terraform, tfInstance, tmpDir, err
 	}
 
 	// download artifact and extract files
@@ -375,7 +376,7 @@ func (r *TerraformReconciler) reconcile(ctx context.Context, runnerClient runner
 			revision,
 			infrav1.ArtifactFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 
 	uploadAndExtractReply, err := runnerClient.UploadAndExtract(ctx, &runner.UploadAndExtractRequest{
@@ -390,20 +391,10 @@ func (r *TerraformReconciler) reconcile(ctx context.Context, runnerClient runner
 			revision,
 			infrav1.ArtifactFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 	workingDir := uploadAndExtractReply.WorkingDir
-	tmpDir := uploadAndExtractReply.TmpDir
-
-	defer func() {
-		cleanupDirReply, err := runnerClient.CleanupDir(ctx, &runner.CleanupDirRequest{TmpDir: tmpDir})
-		if err != nil {
-			log.Error(err, "clean up error")
-		}
-		if cleanupDirReply != nil {
-			log.Info(fmt.Sprintf("clean up dir: %s", cleanupDirReply.Message))
-		}
-	}()
+	tmpDir = uploadAndExtractReply.TmpDir
 
 	var backendConfig string
 	DisableTFK8SBackend := os.Getenv("DISABLE_TF_K8S_BACKEND") == "1"
@@ -452,7 +443,7 @@ terraform {
 
 		log.Info(fmt.Sprintf("write backend config: %s", writeBackendConfigReply.Message))
 		if err != nil {
-			return terraform, err
+			return terraform, tfInstance, tmpDir, err
 		}
 	}
 
@@ -475,7 +466,7 @@ terraform {
 				revision,
 				infrav1.TFExecNewFailedReason,
 				err.Error(),
-			), err
+			), tfInstance, tmpDir, err
 		}
 		tfrcFilepath = processCliConfigReply.FilePath
 	}
@@ -492,7 +483,7 @@ terraform {
 			revision,
 			infrav1.TFExecNewFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 
 	newTerraformReply, err := runnerClient.NewTerraform(ctx,
@@ -508,10 +499,10 @@ terraform {
 			revision,
 			infrav1.TFExecNewFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 
-	tfInstance := newTerraformReply.Id
+	tfInstance = newTerraformReply.Id
 	envs := map[string]string{}
 
 	disableTestLogging := os.Getenv("DISABLE_TF_LOGS") == "1"
@@ -532,7 +523,7 @@ terraform {
 				revision,
 				infrav1.TFExecInitFailedReason,
 				err.Error(),
-			), err
+			), tfInstance, tmpDir, err
 		}
 	}
 
@@ -564,7 +555,7 @@ terraform {
 			revision,
 			infrav1.TFExecInitFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 	log.Info(fmt.Sprintf("init reply: %s", initReply.Message))
 
@@ -573,7 +564,7 @@ terraform {
 	terraformBytes, err := terraform.ToBytes(r.Scheme)
 	if err != nil {
 		// transient error?
-		return terraform, err
+		return terraform, tfInstance, tmpDir, err
 	}
 	generateVarsForTFReply, err := runnerClient.GenerateVarsForTF(ctx, &runner.GenerateVarsForTFRequest{
 		Terraform:  terraformBytes,
@@ -586,11 +577,34 @@ terraform {
 			revision,
 			infrav1.VarsGenerationFailedReason,
 			err.Error(),
-		), err
+		), tfInstance, tmpDir, err
 	}
 	log.Info(fmt.Sprintf("generate vars from tf: %s", generateVarsForTFReply.Message))
 
 	log.Info("generated var files from spec")
+	return terraform, tfInstance, tmpDir, nil
+}
+
+func (r *TerraformReconciler) reconcile(ctx context.Context, runnerClient runner.RunnerClient, terraform infrav1.Terraform, sourceObj sourcev1.Source) (infrav1.Terraform, error) {
+
+	log := ctrl.LoggerFrom(ctx)
+	revision := sourceObj.GetArtifact().Revision
+	objectKey := types.NamespacedName{Namespace: terraform.Namespace, Name: terraform.Name}
+	terraform, tfInstance, tmpDir, err := r.setupTerraform(ctx, runnerClient, terraform, sourceObj, revision, objectKey)
+
+	defer func() {
+		cleanupDirReply, err := runnerClient.CleanupDir(ctx, &runner.CleanupDirRequest{TmpDir: tmpDir})
+		if err != nil {
+			log.Error(err, "clean up error")
+		}
+		if cleanupDirReply != nil {
+			log.Info(fmt.Sprintf("clean up dir: %s", cleanupDirReply.Message))
+		}
+	}()
+
+	if err != nil {
+		return terraform, err
+	}
 
 	if r.shouldDetectDrift(terraform, revision) {
 		var driftDetectionErr error // declared here to avoid shadowing on terraform variable
@@ -625,7 +639,7 @@ terraform {
 	}
 
 	if r.shouldPlan(terraform) {
-		terraform, err = r.plan(ctx, terraform, tfInstance, runnerClient, revision)
+		terraform, err = r.plan(ctx, terraform, tfInstance, runnerClient, revision, false)
 		if err != nil {
 			return terraform, err
 		}
@@ -741,7 +755,7 @@ func (r *TerraformReconciler) detectDrift(ctx context.Context, terraform infrav1
 	return terraform, nil
 }
 
-func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraform, tfInstance string, runnerClient runner.RunnerClient, revision string) (infrav1.Terraform, error) {
+func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraform, tfInstance string, runnerClient runner.RunnerClient, revision string, isDestroyResourcesOnDeletion bool) (infrav1.Terraform, error) {
 
 	log := ctrl.LoggerFrom(ctx)
 
@@ -766,8 +780,8 @@ func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraf
 		planRequest.Out = ""
 	}
 
-	if terraform.Spec.Destroy {
-		log.Info("spec.destroy is set")
+	if terraform.Spec.Destroy || isDestroyResourcesOnDeletion {
+		log.Info("plan to destroy")
 		planRequest.Destroy = true
 	}
 
@@ -1363,8 +1377,53 @@ func (r *TerraformReconciler) fireEvent(ctx context.Context, terraform infrav1.T
 	}
 }
 
-func (r *TerraformReconciler) finalize(ctx context.Context, terraform infrav1.Terraform, runnerClient runner.RunnerClient) (ctrl.Result, error) {
+func (r *TerraformReconciler) finalize(ctx context.Context, terraform infrav1.Terraform, runnerClient runner.RunnerClient, sourceObj sourcev1.Source) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
+	objectKey := types.NamespacedName{Namespace: terraform.Namespace, Name: terraform.Name}
+
+	if terraform.Spec.DestroyResourcesOnDeletion {
+		revision := sourceObj.GetArtifact().Revision
+		terraform, tfInstance, tmpDir, err := r.setupTerraform(ctx, runnerClient, terraform, sourceObj, revision, objectKey)
+
+		defer func() {
+			cleanupDirReply, err := runnerClient.CleanupDir(ctx, &runner.CleanupDirRequest{TmpDir: tmpDir})
+			if err != nil {
+				log.Error(err, "clean up error")
+			}
+			if cleanupDirReply != nil {
+				log.Info(fmt.Sprintf("clean up dir: %s", cleanupDirReply.Message))
+			}
+		}()
+
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		terraform, err = r.plan(ctx, terraform, tfInstance, runnerClient, revision, true)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		if err := r.patchStatus(ctx, objectKey, terraform.Status); err != nil {
+			log.Error(err, "unable to update status after planing")
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		outputs := map[string]tfexec.OutputMeta{}
+		terraform, err = r.apply(ctx, terraform, tfInstance, runnerClient, revision, &outputs)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		if err := r.patchStatus(ctx, objectKey, terraform.Status); err != nil {
+			log.Error(err, "unable to update status after applying")
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		if err == nil {
+			log.Info("finalizing destroyResourcesOnDeletion: ok")
+		}
+	}
 
 	outputSecretName := ""
 	hasSpecifiedOutputSecret := terraform.Spec.WriteOutputsToSecret != nil && terraform.Spec.WriteOutputsToSecret.Name != ""
@@ -1396,6 +1455,10 @@ func (r *TerraformReconciler) finalize(ctx context.Context, terraform infrav1.Te
 
 	// Record deleted status
 	r.recordReadinessMetric(ctx, terraform)
+
+	if err := r.Get(ctx, objectKey, &terraform); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Remove our finalizer from the list and update it
 	controllerutil.RemoveFinalizer(&terraform, infrav1.TerraformFinalizer)

--- a/docs/References/terraform.md
+++ b/docs/References/terraform.md
@@ -550,6 +550,19 @@ Kubernetes core/v1.SecretReference
 <p>List of health checks to be performed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>destroyResourcesOnDeletion</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Create destroy plan and apply it to destroy terraform resources
+upon deletion of this object. Defaults to false.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -787,6 +800,19 @@ Kubernetes core/v1.SecretReference
 <td>
 <em>(Optional)</em>
 <p>List of health checks to be performed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>destroyResourcesOnDeletion</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Create destroy plan and apply it to destroy terraform resources
+upon deletion of this object. Defaults to false.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -279,3 +279,23 @@ spec:
       type: http
       url: "https://example.org"
 ```
+
+## Destroy resources on deletion
+
+The resources created by terraform are not defaulted to destroyed after the object is deleted from the cluster. To enable destroy resources on object deletion, set `.spec.destroyResourcesOnDeletion` to `true`. 
+
+```yaml
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
+metadata:
+  name: helloworld
+  namespace: flux-system
+spec:
+  approvePlan: "auto"
+  destroyResourcesOnDeletion: true
+  path: ./
+  sourceRef:
+    kind: GitRepository
+    name: helloworld
+    namespace: flux-system
+```


### PR DESCRIPTION
The resources created by terraform are not defaulted to destroyed after the object is deleted from the cluster. This feature adds `.spec.destroyResourcesOnDeletion` flag to enable this behavior. To enable destroy resources on object deletion, set `.spec.destroyResourcesOnDeletion` to `true`. 

```yaml
apiVersion: infra.contrib.fluxcd.io/v1alpha1
kind: Terraform
metadata:
  name: helloworld
  namespace: flux-system
spec:
  approvePlan: "auto"
  destroyResourcesOnDeletion: true
  path: ./
  sourceRef:
    kind: GitRepository
    name: helloworld
    namespace: flux-system
```

Addresses https://github.com/weaveworks/tf-controller/issues/96