### PR TITLE
remove the terraform binary from the controller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,6 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tf-controller cmd/manager/main.go
 
-ARG TF_VERSION=1.1.5
-ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip /terraform_${TF_VERSION}_linux_amd64.zip
-RUN unzip -q /terraform_${TF_VERSION}_linux_amd64.zip
-
-
 FROM alpine:3.15
 
 LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controller"
@@ -34,13 +29,12 @@ LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controll
 RUN apk add --no-cache ca-certificates tini git openssh-client gnupg
 
 COPY --from=builder /workspace/tf-controller /usr/local/bin/
-COPY --from=builder /workspace/terraform /usr/local/bin/
 
 # Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-RUN addgroup -S controller && adduser -S controller -G controller && chmod +x /usr/local/bin/terraform
+RUN addgroup -S controller && adduser -S controller -G controller
 
 USER controller
 


### PR DESCRIPTION
We no longer need the Terraform binary inside the controller image because it's now in the Runner Pod image.

Fix #109 