### PR TITLE
use tlscert instead of cacert when validating cert of each pod

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -175,11 +175,11 @@ jobs:
       - name: Verify chaos testing result
         run: |
           kubectl -n chaos-testing get pods
-          kubectl -n chaos-testing wait terraform/helloworld-chaos01 --for=condition=ready --timeout=4m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos02 --for=condition=ready --timeout=4m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos03 --for=condition=ready --timeout=4m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos04 --for=condition=ready --timeout=4m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos05 --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos01 --for=condition=ready --timeout=10m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos02 --for=condition=ready --timeout=10m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos03 --for=condition=ready --timeout=10m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos04 --for=condition=ready --timeout=10m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos05 --for=condition=ready --timeout=10m
       - name: Logs
         run: |
           kubectl -n tf-system logs deploy/source-controller

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -175,11 +175,18 @@ jobs:
       - name: Verify chaos testing result
         run: |
           kubectl -n chaos-testing get pods
-          kubectl -n chaos-testing wait terraform/helloworld-chaos01 --for=condition=ready --timeout=10m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos02 --for=condition=ready --timeout=10m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos03 --for=condition=ready --timeout=10m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos04 --for=condition=ready --timeout=10m
-          kubectl -n chaos-testing wait terraform/helloworld-chaos05 --for=condition=ready --timeout=10m
+
+          kubectl -n chaos-testing wait pod/helloworld-chaos01-tf-runner --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait pod/helloworld-chaos02-tf-runner --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait pod/helloworld-chaos03-tf-runner --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait pod/helloworld-chaos04-tf-runner --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait pod/helloworld-chaos05-tf-runner --for=condition=ready --timeout=4m
+
+          kubectl -n chaos-testing wait terraform/helloworld-chaos01 --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos02 --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos03 --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos04 --for=condition=ready --timeout=4m
+          kubectl -n chaos-testing wait terraform/helloworld-chaos05 --for=condition=ready --timeout=4m
       - name: Logs
         run: |
           kubectl -n tf-system logs deploy/source-controller

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read # for actions/checkout to fetch code
 
+env:
+  CONTROLLER: ${{ github.event.repository.name }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -28,3 +31,70 @@ jobs:
           go-version: 1.17.x
       - name: Run tests
         run: make test
+      - name: Set up yq
+        uses: frenck/action-setup-yq@v1
+        with:
+          version: 4.14.1
+      - name: Setup Kustomize
+        uses: fluxcd/pkg/actions/kustomize@main
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION="${{ steps.branch-name.outputs.head_ref_branch }}-${GITHUB_SHA::8}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: "--debug"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: chanwit
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Publish multi-arch tf-controller container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64 #,linux/arm/v7,linux/arm64
+          tags: |
+            ghcr.io/weaveworks/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
+      - name: Publish multi-arch tf-runner container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./runner.Dockerfile
+          platforms: linux/amd64 #,linux/arm/v7,linux/arm64
+          tags: |
+            ghcr.io/weaveworks/tf-runner:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}

--- a/api/v1alpha1/terraform_types.go
+++ b/api/v1alpha1/terraform_types.go
@@ -469,9 +469,9 @@ func (in *Terraform) FromBytes(b []byte, scheme *runtime.Scheme) error {
 		), b, in)
 }
 
-func (in *Terraform) GetRunnerAddr(ip string, port int) string {
+func (in *Terraform) GetRunnerHostname(ip string) string {
 	prefix := strings.ReplaceAll(ip, ".", "-")
-	return fmt.Sprintf("%s.%s.pod.cluster.local:%d", prefix, in.Namespace, port)
+	return fmt.Sprintf("%s.%s.pod.cluster.local", prefix, in.Namespace)
 }
 
 func trimString(str string, limit int) string {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -194,7 +194,7 @@ func main() {
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 		}
-		go mtls.StartGRPCServer(signalHandlerContext, runnerServer, "localhost:30000", mgr, rotator)
+		go mtls.StartGRPCServerForTesting(signalHandlerContext, runnerServer, "flux-system", "localhost:30000", mgr, rotator)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/testdata/chaos/test.yaml
+++ b/config/testdata/chaos/test.yaml
@@ -3,7 +3,7 @@ kind: Terraform
 metadata:
   name: helloworld-chaos01
 spec:
-  interval: 10s
+  interval: 1m
   approvePlan: "auto"
   path: ./
   sourceRef:
@@ -15,7 +15,7 @@ kind: Terraform
 metadata:
   name: helloworld-chaos02
 spec:
-  interval: 10s
+  interval: 1m
   approvePlan: "auto"
   path: ./
   sourceRef:
@@ -27,7 +27,7 @@ kind: Terraform
 metadata:
   name: helloworld-chaos03
 spec:
-  interval: 10s
+  interval: 1m
   approvePlan: "auto"
   path: ./
   sourceRef:
@@ -39,7 +39,7 @@ kind: Terraform
 metadata:
   name: helloworld-chaos04
 spec:
-  interval: 10s
+  interval: 1m
   approvePlan: "auto"
   path: ./
   sourceRef:
@@ -51,7 +51,7 @@ kind: Terraform
 metadata:
   name: helloworld-chaos05
 spec:
-  interval: 10s
+  interval: 1m
   approvePlan: "auto"
   path: ./
   sourceRef:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -201,13 +201,15 @@ func TestMain(m *testing.M) {
 		DNSName:        "localhost",
 		SecretKey: types.NamespacedName{
 			Namespace: "flux-system",
-			Name:      "tf-controller.tls.test",
+			Name:      "tf-controller.tls",
 		},
 		Ready:                  certsReady,
 		CAValidityDuration:     time.Hour * 24 * 7,
 		CertValidityDuration:   5*time.Minute + 1*time.Hour, // since the cert lookaheadInterval is set to 1 hour, using 1hr5m so that the cert is valid for 5 mins
 		RotationCheckFrequency: 10 * time.Second,
+		LookaheadInterval:      1 * time.Hour,
 	}
+
 	if err := mtls.AddRotator(ctx, k8sManager, rotator); err != nil {
 		panic(err)
 	}
@@ -232,7 +234,7 @@ func TestMain(m *testing.M) {
 		Scheme: k8sManager.GetScheme(),
 	}
 
-	go mtls.StartGRPCServer(ctx, runnerServer, "localhost:30000", k8sManager, rotator)
+	go mtls.StartGRPCServerForTesting(ctx, runnerServer, "flux-system", "localhost:30000", k8sManager, rotator)
 
 	go func() {
 		if err := k8sManager.Start(ctx); err != nil {

--- a/controllers/tc000250_mtls_generate_creds_test.go
+++ b/controllers/tc000250_mtls_generate_creds_test.go
@@ -33,7 +33,7 @@ func Test_000250_mtls_generate_creds_test(t *testing.T) {
 	By("creating a secret and writing the certs")
 	caSecretKey := types.NamespacedName{
 		Namespace: "flux-system",
-		Name:      "tf-controller.tls.test",
+		Name:      "tf-controller.tls",
 	}
 	caSecret := &corev1.Secret{}
 	g.Eventually(func() bool {


### PR DESCRIPTION
Fixes #155 

This PR fixes the validation process of tlscert.

I removed batch pod deletion logic because it might accidentally delete long running pod of other TF objects.
We should let a TF object takes care of its own runner pod only.