### PR TITLE
change the behaviour of pod clean up to be true by default

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,8 +182,8 @@ jobs:
           sleep 20
       - name: Randomly delete runner pods
         run: |
-          # use chaos level 2 at the moment, as we don't have much CPU resources
-          seq 5 | shuf | head -2 | xargs -I{} kubectl -n chaos-testing delete pod helloworld-chaos0{}-tf-runner
+          # use chaos level 3 at the moment, as we don't have much CPU resources
+          seq 5 | shuf | head -3 | xargs -I{} bash -c "kubectl -n chaos-testing delete pod helloworld-chaos0{}-tf-runner || true"
           sleep 60
       - name: Verify chaos testing result
         run: |

--- a/api/v1alpha1/terraform_types.go
+++ b/api/v1alpha1/terraform_types.go
@@ -151,10 +151,10 @@ type TerraformSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// Clean the runner pod up after each reconcilation cycle
-	// +kubebuilder:default:=false
+	// Clean the runner pod up after each reconciliation cycle
+	// +kubebuilder:default:=true
 	// +optional
-	AlwaysCleanupRunnerPod bool `json:"alwaysCleanupRunnerPod,omitempty"`
+	AlwaysCleanupRunnerPod *bool `json:"alwaysCleanupRunnerPod,omitempty"`
 
 	// Configure the termination grace period for the runner pod. Use this parameter
 	// to allow the Terraform process to gracefully shutdown. Consider increasing for
@@ -472,6 +472,14 @@ func (in *Terraform) FromBytes(b []byte, scheme *runtime.Scheme) error {
 func (in *Terraform) GetRunnerHostname(ip string) string {
 	prefix := strings.ReplaceAll(ip, ".", "-")
 	return fmt.Sprintf("%s.%s.pod.cluster.local", prefix, in.Namespace)
+}
+
+func (in *TerraformSpec) GetAlwaysCleanupRunnerPod() bool {
+	if in.AlwaysCleanupRunnerPod == nil {
+		return true
+	}
+
+	return *in.AlwaysCleanupRunnerPod
 }
 
 func trimString(str string, limit int) string {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -205,6 +205,11 @@ func (in *TerraformSpec) DeepCopyInto(out *TerraformSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AlwaysCleanupRunnerPod != nil {
+		in, out := &in.AlwaysCleanupRunnerPod, &out.AlwaysCleanupRunnerPod
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RunnerTerminationGracePeriodSeconds != nil {
 		in, out := &in.RunnerTerminationGracePeriodSeconds, &out.RunnerTerminationGracePeriodSeconds
 		*out = new(int64)

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -49,8 +49,8 @@ spec:
             description: TerraformSpec defines the desired state of Terraform
             properties:
               alwaysCleanupRunnerPod:
-                default: false
-                description: Clean the runner pod up after each reconcilation cycle
+                default: true
+                description: Clean the runner pod up after each reconciliation cycle
                 type: boolean
               approvePlan:
                 description: ApprovePlan specifies name of a plan wanted to approve.

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -155,7 +155,7 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return
 		}
 
-		if terraform.Spec.AlwaysCleanupRunnerPod == true {
+		if terraform.Spec.GetAlwaysCleanupRunnerPod() == true {
 			podKey := getRunnerPodObjectKey(terraform)
 			var pod corev1.Pod
 			if err := cli.Get(ctx, podKey, &pod); err != nil {

--- a/docs/References/terraform.md
+++ b/docs/References/terraform.md
@@ -585,7 +585,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Clean the runner pod up after each reconcilation cycle</p>
+<p>Clean the runner pod up after each reconciliation cycle</p>
 </td>
 </tr>
 <tr>
@@ -876,7 +876,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Clean the runner pod up after each reconcilation cycle</p>
+<p>Clean the runner pod up after each reconciliation cycle</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
We got a bad side-effect of retaining runner pods after use, including a security concern, a TLS problem.
So a runner pod should be clean up by default.

Fixes #164 