### PR TITLE
Setup a SecurityGroupPolicy

### DIFF
--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: The Helm chart for Weave GitOps Terraform Controller
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "v0.9.3"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -49,3 +49,5 @@ The following table lists the configurable parameters of the TF-controller chart
 | `podAnnotations`                                  | `{}`                                        | Additional pod annotations
 | `podSecurityContext`                              | `{}`                                        | Pod security context configurations
 | `securityContext`                                 | `{}`                                        | Container security context configurations
+| `eksSecurityGroupPolicy.create`                   | `false`                                     | Create the EKS SecurityGroupPolicy
+| `eksSecurityGroupPolicy.ids`                      | `[]`                                        | List of AWS Security Group IDs

--- a/charts/tf-controller/templates/security-group-policy.yaml
+++ b/charts/tf-controller/templates/security-group-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.securityGroupPolicy.create }}
+{{- if .Values.eksSecurityGroupPolicy.create }}
 ---
 apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
@@ -14,7 +14,7 @@ spec:
       app.kubernetes.io/name: {{ include "tf-controller.name" . }}
   securityGroups:
     groupIds:
-    {{- with .Values.securityGroupPolicy.ids }}
+    {{- with .Values.eksSecurityGroupPolicy.ids }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/tf-controller/templates/security-group-policy.yaml
+++ b/charts/tf-controller/templates/security-group-policy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.securityGroupPolicy.create }}
+---
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: tf-controller
+  namespace: {{ .Release.Namespace }}
+  # Tell helm to deploy this first
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  serviceAccountSelector:
+    matchLabels:
+      app.kubernetes.io/name: tf-controller
+  securityGroups:
+    groupIds:
+    {{- with .Values.securityGroupPolicy.ids }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/tf-controller/templates/security-group-policy.yaml
+++ b/charts/tf-controller/templates/security-group-policy.yaml
@@ -3,7 +3,7 @@
 apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
 metadata:
-  name: tf-controller
+  name: {{ include "tf-controller.name" . }}
   namespace: {{ .Release.Namespace }}
   # Tell helm to deploy this first
   annotations:
@@ -11,7 +11,7 @@ metadata:
 spec:
   serviceAccountSelector:
     matchLabels:
-      app.kubernetes.io/name: tf-controller
+      app.kubernetes.io/name: {{ include "tf-controller.name" . }}
   securityGroups:
     groupIds:
     {{- with .Values.securityGroupPolicy.ids }}

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -60,3 +60,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Create an AWS EKS Security Group Policy with the supplied Security Group IDs
+# https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#deploy-securitygrouppolicy
+securityGroupPolicy:
+  create: false
+  ids: []
+    #- sg-1234567890
+    #- sg-1234567891
+    #- sg-1234567892
+

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -66,7 +66,6 @@ affinity: {}
 securityGroupPolicy:
   create: false
   ids: []
-    #- sg-1234567890
-    #- sg-1234567891
-    #- sg-1234567892
-
+    # - sg-1234567890
+    # - sg-1234567891
+    # - sg-1234567892

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -63,7 +63,7 @@ affinity: {}
 
 # Create an AWS EKS Security Group Policy with the supplied Security Group IDs
 # https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#deploy-securitygrouppolicy
-securityGroupPolicy:
+eksSecurityGroupPolicy:
   create: false
   ids: []
     # - sg-1234567890


### PR DESCRIPTION
This change will allow setting up an [AWS EKS `SecurityGroupPolicy`](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#deploy-securitygrouppolicy) against the `ServiceAccount` used by the `tf-controller` `POD`s.

If supplied the `POD`s will be started and run under the specific AWS Security Groups that are passed in the list.