### PR TITLE
Update to use ww corporate FOSSA api token

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: fossa-contrib/fossa-action@v1
         with:
           # FOSSA Push-Only API Token
-          fossa-api-key: aa473d645cd22eb77f00985d7bc85034
+          fossa-api-key: b429fea44d610229ac091ed8d1223bb9
           github-token: ${{ github.token }}
 
   codeql:


### PR DESCRIPTION
The current API token is linked to my personal account. Created a new one using corporate account and replacing it.