### PR TITLE
Publish `tfctl` releases to weaveworks/homebrew-tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,3 +63,19 @@ signs:
       - "${artifact}"
     artifacts: checksum
     output: true
+
+brews:
+  - name: tfctl
+    ids:
+    - tfctl
+    tap:
+      owner: weaveworks
+      name: homebrew-tap
+    commit_author:
+      name: weaveworksbot
+      email: team+gitbot@weave.works
+    folder: Formula
+    homepage: https://weaveworks.github.io/tf-controller
+    install: |
+      bin.install "tfctl"
+


### PR DESCRIPTION
This PR enables publishing `tfctl` releases to the weaveworks homebrew tap repository. 

Signed-off-by: Piaras Hoban <phoban01@gmail.com>