### PR TITLE
Go Get move to Go Install + Update of Error

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -31,13 +31,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: go
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
 
   trivy:
     name: Trivy

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -22,7 +22,7 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tf-runner cmd/runner/main.go
 
-ARG TF_VERSION=1.1.9
+ARG TF_VERSION=1.2.0
 ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip /terraform_${TF_VERSION}_linux_amd64.zip
 RUN unzip -q /terraform_${TF_VERSION}_linux_amd64.zip
 

--- a/utils/json_encode_bytes.go
+++ b/utils/json_encode_bytes.go
@@ -22,7 +22,7 @@ func JSONEncodeBytes(b []byte) (*apiextensionsv1.JSON, error) {
 func MustJSONEncodeBytes(t *testing.T, b []byte) *apiextensionsv1.JSON {
 	data, err := json.Marshal(string(b))
 	if err != nil {
-		t.Error(fmt.Errorf("could not encode bytes to json", err))
+		t.Error(fmt.Errorf("could not encode bytes to json: %s", err))
 	}
 	return &apiextensionsv1.JSON{Raw: data}
 }

--- a/utils/json_encode_bytes.go
+++ b/utils/json_encode_bytes.go
@@ -22,7 +22,7 @@ func JSONEncodeBytes(b []byte) (*apiextensionsv1.JSON, error) {
 func MustJSONEncodeBytes(t *testing.T, b []byte) *apiextensionsv1.JSON {
 	data, err := json.Marshal(string(b))
 	if err != nil {
-		t.Error(fmt.Errorf("could not encode bytes to json: %w", err))
+		t.Error(fmt.Errorf("could not encode bytes to json", err))
 	}
 	return &apiextensionsv1.JSON{Raw: data}
 }

--- a/utils/json_encode_bytes.go
+++ b/utils/json_encode_bytes.go
@@ -22,7 +22,7 @@ func JSONEncodeBytes(b []byte) (*apiextensionsv1.JSON, error) {
 func MustJSONEncodeBytes(t *testing.T, b []byte) *apiextensionsv1.JSON {
 	data, err := json.Marshal(string(b))
 	if err != nil {
-		t.Errorf("could not encode bytes to json: %w", err)
+		t.Error(fmt.Errorf("could not encode bytes to json: %w", err))
 	}
 	return &apiextensionsv1.JSON{Raw: data}
 }

--- a/utils/json_encode_bytes.go
+++ b/utils/json_encode_bytes.go
@@ -22,7 +22,7 @@ func JSONEncodeBytes(b []byte) (*apiextensionsv1.JSON, error) {
 func MustJSONEncodeBytes(t *testing.T, b []byte) *apiextensionsv1.JSON {
 	data, err := json.Marshal(string(b))
 	if err != nil {
-		t.Error(fmt.Errorf("could not encode bytes to json: %s", err))
+		t.Errorf("could not encode bytes to json: %s", err))
 	}
 	return &apiextensionsv1.JSON{Raw: data}
 }


### PR DESCRIPTION
- Change `go get` to `go install` due to [deprecation of 'go get' for installing executables](https://go.dev/doc/go-get-install-deprecation)
- Change `json_encode_bytes.go` to fix the error/fmt issue
- Updated `tf-runner` Terraform binary from `1.1.9` to `1.2.0`
- Updated CodeQL from `v1` to `v2`
- Other fixes as per below in PR commentary

NB: the `Terraform` binary will warn on a high severity CVE, this is a false positive. You can read more about the issue here: https://github.com/hashicorp/terraform/issues/30877