### PR TITLE
replace logging lib in runner and display logging in runner console

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -23,9 +23,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/fluxcd/pkg/runtime/logger"
 	flag "github.com/spf13/pflag"
-
 	"github.com/weaveworks/tf-controller/mtls"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 /* Please prepare the following envs for this program
@@ -40,6 +41,10 @@ import (
            fieldPath: metadata.namespace
 */
 
+var (
+	logOptions logger.Options
+)
+
 func main() {
 	var (
 		grpcPort int
@@ -52,6 +57,14 @@ func main() {
 
 	_ = os.Getenv("POD_NAME")
 	podNamespace := os.Getenv("POD_NAMESPACE")
+
+	if os.Getenv("DISABLE_TF_LOGS") != "1" {
+		logOptions = logger.Options{
+			LogEncoding: "json",
+			LogLevel:    "info",
+		}
+		ctrl.SetLogger(logger.NewLogger(logOptions))
+	}
 
 	// catch the SIGTERM from the kubelet to gracefully terminate
 	sigterm := make(chan os.Signal, 1)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -82,7 +82,6 @@ func TestMain(m *testing.M) {
 	var logSink io.Writer
 
 	logSink = os.Stderr
-
 	if os.Getenv("DISABLE_K8S_LOGS") == "1" {
 		logSink = io.Discard
 	}

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -38,7 +38,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/predicates"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
-	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha1"
@@ -413,14 +412,6 @@ func (r *TerraformReconciler) shouldDoHealthChecks(terraform infrav1.Terraform) 
 	}
 
 	return false
-}
-
-type LocalPrintfer struct {
-	logger logr.Logger
-}
-
-func (l LocalPrintfer) Printf(format string, v ...interface{}) {
-	l.logger.Info(fmt.Sprintf(format, v...))
 }
 
 func (r *TerraformReconciler) reconcile(ctx context.Context, runnerClient runner.RunnerClient, terraform infrav1.Terraform, sourceObj sourcev1.Source) (retTerraform infrav1.Terraform, retErr error) {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/rs/zerolog v1.26.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.11.0


### PR DESCRIPTION
We enable info-level logs by default also for Runner.
To disable logging for Runner, set `DISABLE_TF_LOGS=1` to the runnerPodTemplate.

Also fixes: #203

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>