### PR TITLE
fix sensitive logging in runner

### DIFF
--- a/runner/server.go
+++ b/runner/server.go
@@ -181,7 +181,9 @@ func (r *TerraformRunnerServer) NewTerraform(ctx context.Context, req *NewTerraf
 	if !disableTestLogging {
 		r.tf.SetStdout(os.Stdout)
 		r.tf.SetStderr(os.Stderr)
-		r.tf.SetLogger(&LocalPrintfer{logger: log})
+		if os.Getenv("ENABLE_SENSITIVE_TF_LOGS") == "1" {
+			r.tf.SetLogger(&LocalPrintfer{logger: log})
+		}
 	}
 
 	return &NewTerraformReply{Id: "1"}, nil


### PR DESCRIPTION
Fixes #239 

This commit disables sensitive logging by default.
By default Terraform logs are shown, but sensitive logs will be now displayed only when `ENABLE_SENSITIVE_TF_LOGS=1`.
If `DISABLE_TF_LOGS=1` the Terraform logging will be disabled entirely.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>