### PR TITLE
Correct IRSA use case docs to annotate runner instead of controller

### DIFF
--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -85,7 +85,8 @@ spec:
 ## Use with AWS EKS IRSA
 
 AWS Elastic Kubernetes Service (EKS) offers IAM Roles for Service Accounts (IRSA) as a mechanism by which to provide
-credentials for the Terraform controller.
+credentials to Kubernetes pods. This can be used to provide the required AWS credentials to Terraform runners
+for performing plans and applies.
 
 You can use `eksctl` to associate an OIDC provider with your EKS cluster, for example:
 
@@ -96,12 +97,21 @@ eksctl utils associate-iam-oidc-provider --cluster CLUSTER_NAME --approve
 Then follow the instructions [here](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html)
 to add a trust policy to the IAM role which grants the necessary permissions for Terraform.
 Please note that if you have installed the controller following the README, then the `namespace:serviceaccountname`
-will be `flux-system:tf-controller`. You'll obtain a Role ARN to use in the next step.
+will be `flux-system:tf-runner`. You'll obtain a Role ARN to use in the next step.
 
-Finally, annotate the ServiceAccount with the obtained Role ARN in your cluster:
+Finally, annotate the ServiceAccount for the `tf-runner` with the obtained Role ARN in your cluster:
 
 ```shell
-kubectl annotate -n flux-system serviceaccount tf-controller eks.amazonaws.com/role-arn=ROLE_ARN
+kubectl annotate -n flux-system serviceaccount tf-runner eks.amazonaws.com/role-arn=ROLE_ARN
+```
+
+If deploying the `tf-controller` via Helm, this can be accomplished as follows:
+```yaml
+values:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: ROLE_ARN
 ```
 
 ## Setting Terraform Variables


### PR DESCRIPTION
Annotating the controller does not expose the AWS credentials to the AWS Terraform provider. The credentials need to be provided on the runner.