### PR TITLE
fixed a race condition that allows grpc client and the runner to use different secrets

### DIFF
--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -1882,7 +1882,7 @@ func (r *TerraformReconciler) reconcileRunnerPod(ctx context.Context, terraform 
 		}
 	}
 
-	log.Info("show runner pod state: ", "state", podState)
+	log.Info("show runner pod state: ", "name", terraform.Name, "state", podState)
 
 	switch podState {
 	case stateNotFound:

--- a/mtls/rotator.go
+++ b/mtls/rotator.go
@@ -173,9 +173,12 @@ tickerLoop:
 			if err := cr.refreshCACertsIfNeeded(); err != nil {
 				crLog.Error(err, "could not refresh cert")
 			}
-			n := len(cr.artifactCaches)
-			secret := cr.artifactCaches[n-1].certSecret
-			trigger.Ready <- &TriggerResult{Secret: secret, Err: nil}
+			// if no channel passing it, skip
+			if trigger.Ready != nil {
+				n := len(cr.artifactCaches)
+				secret := cr.artifactCaches[n-1].certSecret
+				trigger.Ready <- &TriggerResult{Secret: secret, Err: nil}
+			}
 
 		case <-ticker.C:
 			if err := cr.refreshCACertsIfNeeded(); err != nil {


### PR DESCRIPTION
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

From pprof, we found a hidden race condition between assigning TLS for the runner and obtaining TLS for gRPC client.

```
549 @ 0x439b56 0x4498f2 0x88661b 0x880b55 0x89880c 0x8978b5 0x896f3f 0x896c4e 0x87a99d 0x87a885 0x14f160e 0x1685d6c 0x1683505 0x1681510 0x14159ef 0x1417a7e 0x14172c5 0x1416c85 0x46ae01
#	0x88661a	google.golang.org/grpc.(*pickerWrapper).pick+0x21a						/go/pkg/mod/google.golang.org/grpc@v1.45.0/picker_wrapper.go:103
#	0x880b54	google.golang.org/grpc.(*ClientConn).getTransport+0x34						/go/pkg/mod/google.golang.org/grpc@v1.45.0/clientconn.go:962
#	0x89880b	google.golang.org/grpc.(*clientStream).newAttemptLocked+0x84b					/go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:410
#	0x8978b4	google.golang.org/grpc.newClientStreamWithParams+0x8f4						/go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:300
#	0x896f3e	google.golang.org/grpc.newClientStream.func2+0x9e						/go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:186
#	0x896c4d	google.golang.org/grpc.newClientStream+0x48d							/go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:214
#	0x87a99c	google.golang.org/grpc.invoke+0x7c								/go/pkg/mod/google.golang.org/grpc@v1.45.0/call.go:66
#	0x87a884	google.golang.org/grpc.(*ClientConn).Invoke+0x264						/go/pkg/mod/google.golang.org/grpc@v1.45.0/call.go:37
#	0x14f160d	github.com/weaveworks/tf-controller/runner.(*runnerClient).UploadAndExtract+0xcd		/workspace/runner/runner_grpc.pb.go:85
#	0x1685d6b	github.com/weaveworks/tf-controller/controllers.(*TerraformReconciler).setupTerraform+0x34b	/workspace/controllers/terraform_controller.go:627
#	0x1683504	github.com/weaveworks/tf-controller/controllers.(*TerraformReconciler).reconcile+0x244		/workspace/controllers/terraform_controller.go:432
#	0x168150f	github.com/weaveworks/tf-controller/controllers.(*TerraformReconciler).Reconcile+0x12cf		/workspace/controllers/terraform_controller.go:266
#	0x14159ee	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile+0x26e		/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114
#	0x1417a7d	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler+0x33d	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311
#	0x14172c4	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem+0x204	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266
#	0x1416c84	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2+0x84		/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227
```