### PR TITLE
fix(tfctl): show plan current working directory

### DIFF
--- a/tfctl/show_plan.go
+++ b/tfctl/show_plan.go
@@ -62,7 +62,12 @@ func (c *CLI) ShowPlan(out io.Writer, resource string) error {
 		return fmt.Errorf("failed to write plan: %w", err)
 	}
 
-	tf, err := tfexec.NewTerraform(tmpDir, c.terraform)
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	tf, err := tfexec.NewTerraform(wd, c.terraform)
 	if err != nil {
 		return fmt.Errorf("failed to create Terraform instance: %w", err)
 	}


### PR DESCRIPTION
Showing plan sometimes requires `terraform` to access the source code (https://github.com/hashicorp/terraform/issues/21966).

I'm unable to display plans without this fix, got:
```
Error: failed to parse Terraform plan: exit status 1

Error: Failed to load plugin schemas

Error while loading schemas for plugin components: 7 problems:

- Failed to obtain provider schema: Could not load the schema for provider
registry.terraform.io/gavinbunney/kubectl: failed to instantiate provider
"registry.terraform.io/gavinbunney/kubectl" to obtain schema: unavailable
provider "registry.terraform.io/gavinbunney/kubectl".
- Failed to obtain provider schema: Could not load the schema for provider
registry.terraform.io/hashicorp/aws: failed to instantiate provider
"registry.terraform.io/hashicorp/aws" to obtain schema: unavailable provider
"registry.terraform.io/hashicorp/aws".
[...]
```

Plan shows fine with the fix.

Note: my computer has Golang 1.18 and `make test` fails because of `go get` [changes](https://go.dev/doc/go-get-install-deprecation#:~:text=In%20Go%201.18%2C%20go%20get,the%20%2Dd%20flag%20were%20enabled.). Would be nice to bump Golang or isolate it.

