### PR TITLE
start to use YAMLs in tests

### DIFF
--- a/controllers/tc000010_no_outputs_test.go
+++ b/controllers/tc000010_no_outputs_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -79,22 +80,24 @@ func Test_000010_no_outputs_test(t *testing.T) {
 
 	Given("a Terraform resource with auto approve, attached to the given GitRepository resource.")
 	By("creating a new TF resource and attaching to the repo via `sourceRef`.")
-	helloWorldTF := infrav1.Terraform{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      terraformName,
-			Namespace: "flux-system",
-		},
-		Spec: infrav1.TerraformSpec{
-			ApprovePlan: "auto",
-			Path:        "./terraform-hello-world-example",
-			SourceRef: infrav1.CrossNamespaceSourceReference{
-				Kind:      "GitRepository",
-				Name:      sourceName,
-				Namespace: "flux-system",
-			},
-			Interval: metav1.Duration{Duration: time.Second * 10},
-		},
-	}
+	var helloWorldTF infrav1.Terraform
+	err := helloWorldTF.FromBytes([]byte(fmt.Sprintf(`
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
+metadata:
+  name: %s
+  namespace: flux-system
+spec:
+  approvePlan: auto
+  path: ./terraform-hello-world-example
+  sourceRef:
+    kind: GitRepository
+    name: %s
+    namespace: flux-system
+  interval: 10s
+`, terraformName, sourceName)), runnerServer.Scheme)
+	g.Expect(err).ToNot(HaveOccurred())
+
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()


### PR DESCRIPTION
Tests are very useful in addition to documents.
They can be examples for users on how to use the API.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>