### PR TITLE
Fix the test to actually test the selector changes

### DIFF
--- a/controllers/tc000310_node_selector_affinity_tolerations_test.go
+++ b/controllers/tc000310_node_selector_affinity_tolerations_test.go
@@ -85,6 +85,8 @@ func Test_000310_node_selector_test(t *testing.T) {
 	By("creating a new TF resource and attaching to the repo via `sourceRef`, with no .spec.approvePlan specified.")
 	helloWorldTF := infrav1.Terraform{}
 	err := helloWorldTF.FromBytes([]byte(fmt.Sprintf(`
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
 metadata:
   name: %s
   namespace: flux-system
@@ -196,6 +198,8 @@ func Test_000310_affinity_test(t *testing.T) {
 	By("creating a new TF resource and attaching to the repo via `sourceRef`, with no .spec.approvePlan specified.")
 	helloWorldTF := infrav1.Terraform{}
 	err := helloWorldTF.FromBytes([]byte(fmt.Sprintf(`
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
 metadata:
   name: %s
   namespace: flux-system
@@ -330,6 +334,8 @@ func Test_000310_tolerations_test(t *testing.T) {
 	By("creating a new TF resource and attaching to the repo via `sourceRef`, with no .spec.approvePlan specified.")
 	helloWorldTF := infrav1.Terraform{}
 	err := helloWorldTF.FromBytes([]byte(fmt.Sprintf(`
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
 metadata:
   name: %s
   namespace: flux-system


### PR DESCRIPTION
This PR:

- sets up the `Terraform` resources  in the `000310` tests using yaml strings rather than building up the object in Go.
- fixes the `000310` tests so that they are checking the generated `PodSpec` that the reconciler creates.

This break was called out in #331 