### PR TITLE
Run destroy with disabled backend on res deletion

### DIFF
--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -1277,7 +1277,7 @@ func (r *TerraformReconciler) apply(ctx context.Context, terraform infrav1.Terra
 
 	// this a special case, when backend is completely disabled.
 	// we need to use "destroy" command instead of apply
-	if r.backendCompletelyDisable(terraform) && terraform.Spec.Destroy == true {
+	if r.backendCompletelyDisable(terraform) || terraform.Spec.Destroy == true {
 		destroyReply, err := runnerClient.Destroy(ctx, &runner.DestroyRequest{
 			TfInstance: tfInstance,
 			Targets:    terraform.Spec.Targets,


### PR DESCRIPTION
When deleting terraform object from the cluster which have backend disabled. Object is deleted without destroy command actually run. This happend due to Spec.Destroy is set to false and condition expects both to be true.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>