### PR TITLE
allow envFrom to make mounting secrets easier

### DIFF
--- a/charts/tf-controller/templates/deployment.yaml
+++ b/charts/tf-controller/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
         {{- end }}
+        {{- if .Values.extraEnvFrom }}
+        envFrom:
+        {{- toYaml .Values.extraEnvFrom | nindent 8 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -40,6 +40,7 @@ resources:
     memory: 64Mi
 # -- Additional container environment variables.
 extraEnv: {}
+extraEnvFrom: []
 # -- Pod-level security context
 podSecurityContext:
   fsGroup: 1337


### PR DESCRIPTION
this PR would allow specifying envFrom in values.yaml in order to set up secrets (think, cloud provider keys etc)