### PR TITLE
Replace backendConfigPath with Override Files format

### DIFF
--- a/runner/server.go
+++ b/runner/server.go
@@ -118,7 +118,7 @@ func (r *TerraformRunnerServer) CleanupDir(ctx context.Context, req *CleanupDirR
 
 func (r *TerraformRunnerServer) WriteBackendConfig(ctx context.Context, req *WriteBackendConfigRequest) (*WriteBackendConfigReply, error) {
 	log := ctrl.LoggerFrom(ctx).WithName(loggerName)
-	const backendConfigPath = "generated_backend_config.tf"
+	const backendConfigPath = "backend_override.tf"
 	log.Info("write backend config", "path", req.DirPath, "config", backendConfigPath)
 	filePath, err := securejoin.SecureJoin(req.DirPath, backendConfigPath)
 	if err != nil {


### PR DESCRIPTION
Terraform has special handling of any configuration file whose name ends in `_override.tf` or `_override.tf.json`. This special handling also applies to a file named literally `override.tf` or `override.tf.json`.

By renaming `backendConfigPath` to `backend_override.tf` it'll allow `backendConfig.customConfiguration` to be set and overwritten as expected when a backend is already defined in the Terraform Module.

Fixes: #389