### PR TITLE
 Fix runner service account template not returning multiple documents when defining allowedNamespaces

### DIFF
--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: The Helm chart for Weave GitOps Terraform Controller
 type: application
-version: 0.8.8
+version: 0.8.9
 appVersion: "v0.13.0-rc.10"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -1,6 +1,6 @@
 # Weave GitOps Terraform Controller
 
-![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0-rc.10](https://img.shields.io/badge/AppVersion-v0.13.0--rc.10-informational?style=flat-square)
+![Version: 0.8.9](https://img.shields.io/badge/Version-0.8.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0-rc.10](https://img.shields.io/badge/AppVersion-v0.13.0--rc.10-informational?style=flat-square)
 
 The Helm chart for Weave GitOps Terraform Controller
 

--- a/charts/tf-controller/templates/runner-serviceaccount.yaml
+++ b/charts/tf-controller/templates/runner-serviceaccount.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.runner.serviceAccount.create -}}
 {{- range include "tf-controller.runner.allowedNamespaces" . | fromJsonArray }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Fixes the following issue:

```
Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:\n  line 16: mapping key \"apiVersion\" already defined at line 2\n  line 17: mapping key \"kind\" already defined at line 3\n  line 18: mapping key \"metadata\" already defined at line 4
```