### PR TITLE
add support to set kube client config flags

### DIFF
--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: The Helm chart for Weave GitOps Terraform Controller
 type: application
-version: 0.9.5
+version: 0.9.6
 appVersion: "v0.13.1"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -1,6 +1,6 @@
 # Weave GitOps Terraform Controller
 
-![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
+![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
 
 The Helm chart for Weave GitOps Terraform Controller
 
@@ -45,6 +45,8 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | image.tag | string | `.Chart.AppVersion` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Controller image pull secret |
 | installCRDs | bool | `true` | If `true`, install CRDs as part of the helm installation |
+| kubeAPIBurst | int | `100` | Argument for `--kube-api-burst` (Controller).  Burst indicates the maximum burst queries-per-second of requests sent to the Kubernetes API, defaults to 100. |
+| kubeAPIQPS | int | `50` | Argument for `--kube-api-qps` (Controller).  Kube API QPS indicates the maximum queries-per-second of requests sent to the Kubernetes API, defaults to 50. |
 | logLevel | string | `"info"` | Level of logging of the controller (Controller) |
 | metrics.enabled | bool | `false` | Enable Metrics Service |
 | metrics.serviceMonitor.annotations | object | `{}` | Assign additional Annotations |

--- a/charts/tf-controller/templates/deployment.yaml
+++ b/charts/tf-controller/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         - --runner-creation-timeout={{ .Values.runner.creationTimeout }}
         - --runner-grpc-max-message-size={{ .Values.runner.grpc.maxMessageSize }}
         - --events-addr={{ .Values.eventsAddress }}
+        - --kube-api-qps={{ .Values.kubeAPIQPS }}
+        - --kube-api-burst={{ .Values.kubeAPIBurst }}
         command:
         - /sbin/tini
         - --

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -90,6 +90,12 @@ certValidityDuration: 6h0m
 caCertValidityDuration: 168h0m
 # -- Argument for `--events-addr` (Controller). The event address, default to the address of the Notification Controller
 eventsAddress: http://notification-controller.flux-system.svc.cluster.local./
+# -- Argument for `--kube-api-qps` (Controller).
+#  Kube API QPS indicates the maximum queries-per-second of requests sent to the Kubernetes API, defaults to 50.
+kubeAPIQPS: 50
+# -- Argument for `--kube-api-burst` (Controller).
+#  Burst indicates the maximum burst queries-per-second of requests sent to the Kubernetes API, defaults to 100.
+kubeAPIBurst: 100
 awsPackage:
   install: true
   tag: v4.38.0-v1alpha11


### PR DESCRIPTION
We're running into kube client rate-limiting errors due to which the TLS secret creation fails, thus causing the `runner` pod to go into `CrashLoopBackoff`

```
kubectl logs -f demo-workload-6x7k1b-tf-runner
2022/12/09 00:08:28 Starting the runner... version sha
I1209 00:08:29.652396 7 request.go:682] Waited for 1.03721706s due to client-side throttling, not priority and fairness, request: GET:
[https://10.100.0.1:443/apis/certificates.k8s.io/v1?timeout=32s](https://10.100.0.1/apis/certificates.k8s.io/v1?timeout=32s)
2022/12/09 00:08:30 secrets "terraform-runner.tls-1671035316" not found
```

We were able to fix this manually by setting the `kube-api-qps` and `kube-api-burst` flags, but these are not exposed to us via the helm chart