### PR TITLE
Selector labels and custom labels had different indentation

### DIFF
--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: The Helm chart for Weave GitOps Terraform Controller
 type: application
-version: 0.9.7
+version: 0.9.8
 appVersion: "v0.13.1"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -1,6 +1,6 @@
 # Weave GitOps Terraform Controller
 
-![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
+![Version: 0.9.8](https://img.shields.io/badge/Version-0.9.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
 
 The Helm chart for Weave GitOps Terraform Controller
 

--- a/charts/tf-controller/templates/deployment.yaml
+++ b/charts/tf-controller/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "tf-controller.selectorLabels" . | nindent 10 }}
+        {{- include "tf-controller.selectorLabels" . | nindent 8 }}
     spec:
       {{- if not .Values.serviceAccount.create }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
This lead to invalid YAML because when set the resulting labels would format to something like this:

```yaml
labels:
  customlabel: test
    selectorlabel: test
```