### PR TITLE
chore(tf-version): bump from 1.3.1 to 1.3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           go-version: 1.19.x
       - name: Setup Terraform
         run: |
-          export TF_VERSION=1.3.1
+          export TF_VERSION=1.3.7
           wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
           unzip -q terraform_${TF_VERSION}_linux_amd64.zip
           mv terraform $(which terraform)

--- a/runner-azure.Dockerfile
+++ b/runner-azure.Dockerfile
@@ -26,7 +26,7 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tf-runner cmd/runner/main.go
 
-ARG TF_VERSION=1.3.1
+ARG TF_VERSION=1.3.7
 ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip /terraform_${TF_VERSION}_linux_amd64.zip
 RUN unzip -q /terraform_${TF_VERSION}_linux_amd64.zip
 

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -26,7 +26,7 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=all="-N -l" -a -o tf-runner cmd/runner/main.go
 
-ARG TF_VERSION=1.3.1
+ARG TF_VERSION=1.3.7
 ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip /terraform_${TF_VERSION}_linux_amd64.zip
 RUN unzip -q /terraform_${TF_VERSION}_linux_amd64.zip
 


### PR DESCRIPTION
Hello!

I'm in need of OIDC support using the AzureRM Backend which was released in Terraform version v1.3.4. 

Hopefully it is enough to just bump the version. Let me know if I need to update anything else.