### PR TITLE
Allow customizing controller log encoding

### DIFF
--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: The Helm chart for Weave GitOps Terraform Controller
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "v0.13.1"

--- a/charts/tf-controller/README.md
+++ b/charts/tf-controller/README.md
@@ -1,6 +1,6 @@
 # Weave GitOps Terraform Controller
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.1](https://img.shields.io/badge/AppVersion-v0.13.1-informational?style=flat-square)
 
 The Helm chart for Weave GitOps Terraform Controller
 
@@ -47,6 +47,7 @@ __Note__: If you need to use the `imagePullSecrets` it would be best to set `ser
 | installCRDs | bool | `true` | If `true`, install CRDs as part of the helm installation |
 | kubeAPIBurst | int | `100` | Argument for `--kube-api-burst` (Controller).  Burst indicates the maximum burst queries-per-second of requests sent to the Kubernetes API, defaults to 100. |
 | kubeAPIQPS | int | `50` | Argument for `--kube-api-qps` (Controller).  Kube API QPS indicates the maximum queries-per-second of requests sent to the Kubernetes API, defaults to 50. |
+| logEncoding | string | `"json"` | Argument for `--log-encoding`. Can be 'json' or 'console'. (Controller) |
 | logLevel | string | `"info"` | Level of logging of the controller (Controller) |
 | metrics.enabled | bool | `false` | Enable Metrics Service |
 | metrics.serviceMonitor.annotations | object | `{}` | Assign additional Annotations |

--- a/charts/tf-controller/templates/deployment.yaml
+++ b/charts/tf-controller/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - args:
         - --watch-all-namespaces
         - --log-level={{ .Values.logLevel }}
-        - --log-encoding=json
+        - --log-encoding={{ .Values.logEncoding }}
         - --enable-leader-election
         - --concurrent={{ .Values.concurrency }}
         - --ca-cert-validity-duration={{ .Values.caCertValidityDuration }}

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -77,7 +77,8 @@ volumeMounts: []
 
 # -- PriorityClassName property for the TF-Controller deployment
 priorityClassName: ""
-# Runner
+# -- Argument for `--log-encoding`. Can be 'json' or 'console'. (Controller)
+logEncoding: json
 # -- Level of logging of the controller (Controller)
 logLevel: info
 # -- Concurrency of the controller (Controller)


### PR DESCRIPTION
Add the ability to customize log encoding on the controller in the chart

Fixes #522 