### PR TITLE
Update Flux APIs and use OCI HelmRepository

### DIFF
--- a/config/samples/infra_v1alpha1_terraform.yaml
+++ b/config/samples/infra_v1alpha1_terraform.yaml
@@ -1,6 +1,0 @@
-apiVersion: infra.contrib.fluxcd.io/v1alpha1
-kind: Terraform
-metadata:
-  name: terraform-sample
-spec:
-  # TODO(user): Add fields here

--- a/config/samples/infra_v1alpha2_terraform.yaml
+++ b/config/samples/infra_v1alpha2_terraform.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: helloworld
+  namespace: flux-system
+spec:
+  interval: 30s
+  url: https://github.com/tf-controller/helloworld
+  ref:
+    branch: main
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: helloworld
+  namespace: flux-system
+spec:
+  interval: 1m
+  approvePlan: auto
+  path: ./
+  sourceRef:
+    kind: GitRepository
+    name: helloworld
+    namespace: flux-system

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,7 +58,7 @@ Here's a simple example of how to GitOps your Terraform resources with TF-contro
 First, we need to define a Source controller's source (`GitRepository`, `Bucket`, `OCIRepository`), for example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: helloworld

--- a/docs/rc.yaml
+++ b/docs/rc.yaml
@@ -1,12 +1,13 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: tf-controller
   namespace: flux-system
 spec:
   interval: 1h0s
-  url: https://weaveworks.github.io/tf-controller/
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/docs/release.yaml
+++ b/docs/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: tf-controller


### PR DESCRIPTION
Changes:
- Switch the v0.15.0-rc.1 Helm installer to OCI HelmRepository
- Bump Flux APIs
- Add proper sample config