### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,6 @@
 In alphabetical order:
 
 Chanwit Kaewkasi, Weaveworks <chanwit@weave.works> (github: @chanwit)
+Luke Mallon, Weaveworks <luke.mallon@weave.works> (github: @Nalum)
 Piaras Hoban, Weaveworks <piaras@weave.works> (github: @phoban01)
 Tom Huang, Weaveworks <tom.huang@weave.works> (github: @tomhuang12)


### PR DESCRIPTION
Luke Mallon, known as @Nalum, has been contributing invaluable patches and dedicating significant time for thorough code reviews, greatly benefiting the project.

Given his substantial contributions and dedication to thorough code reviews, Luke has demonstrated the expertise and commitment that would make him an excellent project maintainer.

cc @phoban01 @tomhuang12 