### PR TITLE
Establishing an RFC Process

### DIFF
--- a/rfcs/DECISION_MAKING.md
+++ b/rfcs/DECISION_MAKING.md
@@ -1,0 +1,44 @@
+## Decision Making
+
+In the Terraform Controller project, we aim for consensus in all our decisions.
+Our communication channels (GitHub, public meetings, RFCs, etc) facilitate agreement before setting up a vote.
+
+If a decision can't be reached or the situation is unclear,
+this typically indicates that we need more information.
+In such cases, we seek additional input from users, related projects, or teams in Weaveworks Product and/or Engineering.
+
+### Deciders
+
+- Repository Maintainers: Decisions that affect the Terraform Controller repository.
+- Weaveworks Tech Leads, Product Managers, Principal Engineers: Decisions that are outside the scope of the Terraform
+  Controller repository but are related to project direction, product strategy, and higher-level technical decisions.
+
+### Decision Guidelines
+
+- Decisions needing wider input are made public by following these guidelines and the Proposal Process.
+- Regardless of whether wider input is required, we believe that the best decisions are reached through Consensus.
+- Most decisions begin by seeking Lazy Consensus.
+- If an objection is raised during the Lazy Consensus process, Deciders work together to seek a mutually agreeable
+  solution.
+- If Consensus cannot be reached, but a decision needs to be made, the next step is to agree on calling a vote. This
+  step is important as it allows dissenting views a chance to request more information or present additional points.
+- If a vote is agreed upon, the default is a Simple Majority.
+- However, there may be situations that necessitate a stronger form of voting – Supermajority – specified below:
+
+### Simple Majority Decisions
+
+If a vote is called, the default is a Simple Majority Vote – more than half of all Deciders.
+
+### Supermajority Decisions
+
+If a vote is called, the following decisions require a Supermajority Vote – two-thirds or more of all Deciders:
+
+- Enforcing a Code of Conduct violation by a community member.
+- Licensing and intellectual property changes.
+- Material changes to the Governance document.
+    - Note: Editorial changes to governance can be made by lazy consensus unless challenged. These changes might fix
+      spelling or grammar, update work affiliations, or reflect an external and evident reality. They do not change the
+      intention or meaning of anything in this document.
+
+Please note that since Terraform Controller is a single repository project, all the maintainers, Weaveworks Tech Leads,
+Product Managers, and Principal Engineers are considered Deciders for the purposes of this decision-making process.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,43 @@
+# Terraform Controller RFCs
+
+In many situations, enhancements and new features are proposed
+on [tf-controller/discussions](https://github.com/weaveworks/tf-controller/discussions).
+These proposals are evaluated publicly by maintainers, contributors, users, and any other interested parties. After a
+consensus is reached among the participants, the proposed changes proceed to the pull request stage where the
+implementation specifics are reviewed, and either approved or rejected by the maintainers.
+
+For **substantial** proposals, we necessitate a systematic design process to ensure all stakeholders can be confident
+about the direction in which the Terraform Controller project is progressing.
+
+The "RFC" (request for comments) process aims to offer a uniform and controlled pathway for significant changes to be
+incorporated into the Terraform Controller project.
+
+Examples of substantial changes include:
+
+- API additions (new types of resources, new relationships between existing APIs)
+- API breaking changes (new mandatory fields, field removals)
+- Security-related changes (Terraform Controller permissions, tenant isolation and impersonation)
+- Drop capabilities (discontinuation of an existing integration with an external service due to security concerns)
+
+## RFC Process
+
+- Prior to submitting an RFC, please discuss the proposal with the Terraform Controller community. Initiate a discussion
+  on GitHub and solicit feedback. You must find a sponsor for the RFC who could be a project maintainer, a Weaveworks
+  Tech Lead, a Weaveworks Product Manager, or a Weaveworks Principal Engineer.
+- Submit an RFC by opening a pull request using [RFC-0000](RFC-0000/README.md) as a template.
+- The sponsor will assign the PR to themselves, label the PR with `area/RFC`, and request other maintainers to begin the
+  review process.
+- Incorporate feedback by adding commits without altering the history.
+- The proposal can only be merged after it has been approved by either **two project maintainers**, or **one project
+  maintainer and one individual from the following**: a Weaveworks Tech Lead, a Weaveworks Product Manager, or a
+  Weaveworks Principal Engineer. The approvers must be satisfied that a [suitable level of consensus](DECISION_MAKING.md) has been achieved.
+- Before the merge, an RFC number is assigned by the sponsor and the PR branch must be rebased with the main.
+- Once merged, the proposal may be implemented in Terraform Controller. The progress can be tracked using the RFC
+  number (used as a prefix for issues and PRs).
+- Once the proposal implementation is available in a release candidate or final release, the RFC should be updated with
+  the Terraform Controller version added to the "Implementation History" section.
+- During the implementation phase, the RFC may be discarded due to security or performance concerns. In this scenario,
+  the RFC "Implementation History" should outline the reasons for rejection. The final decision on the feasibility of a
+  particular implementation rests with the maintainers who reviewed the code changes.
+- A new RFC can be submitted with the aim of replacing an RFC that was rejected during implementation. The new RFC must
+  propose a solution to the issues that led to the rejection of the previous RFC.

--- a/rfcs/RFC-0000/README.md
+++ b/rfcs/RFC-0000/README.md
@@ -1,0 +1,92 @@
+# RFC-NNNN Title
+
+<!--
+The title must be short and descriptive.
+-->
+
+**Status:** provisional
+
+<!--
+Status represents the current state of the RFC.
+Must be one of `provisional`, `implementable`, `implemented`, `deferred`, `rejected`, `withdrawn`, or `replaced`.
+-->
+
+**Creation date:** YYYY-MM-DD
+
+**Last update:** YYYY-MM-DD
+
+## Summary
+
+<!--
+One paragraph explanation of the proposed feature or enhancement.
+-->
+
+## Motivation
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this RFC. Describe why the change is important and the benefits to users.
+-->
+
+### Goals
+
+<!--
+List the specific goals of this RFC. What is it trying to achieve? How will we
+know that this has succeeded?
+-->
+
+### Non-Goals
+
+<!--
+What is out of scope for this RFC? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+## Proposal
+
+<!--
+This is where we get down to the specifics of what the proposal actually is.
+This should have enough detail that reviewers can understand exactly what
+you're proposing, but should not include things like API designs or
+implementation.
+
+If the RFC goal is to document best practices,
+then this section can be replaced with the actual documentation.
+-->
+
+### User Stories
+
+<!--
+Optional if existing discussions and/or issues are linked in the motivation section.
+-->
+
+### Alternatives
+
+<!--
+List plausible alternatives to the proposal and explain why the proposal is superior.
+
+This is a good place to incorporate suggestions made during discussion of the RFC.
+-->
+
+## Design Details
+
+<!--
+This section should contain enough information that the specifics of your
+change are understandable. This may include API specs and code snippets.
+
+The design details should address at least the following questions:
+- How can this feature be enabled / disabled?
+- Does enabling the feature change any default behavior?
+- Can the feature be disabled once it has been enabled?
+- How can an operator determine if the feature is in use?
+- Are there any drawbacks when enabling this feature?
+-->
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of the RFC such as:
+- The first Terraform Controller release where an initial version of the RFC was available.
+- The version of Terraform Controller where the RFC graduated to general availability.
+- The version of Terraform Controller where the RFC was retired or superseded.
+-->


### PR DESCRIPTION
Our goal in this PR is to institute an RFC (Request for Comments) process, drawing inspiration from the existing Flux's v2 RFC framework.

Upon successful implementation of this process, we will proceed to address the considerations outlined in issue #595 via a comprehensive RFC.

According to the RFC process, a proposal can only be merged after it has been approved by either
- **two project maintainers**, or
- **one project maintainer and one individual from the following**: a Weaveworks Tech Lead, a Weaveworks Product Manager, or a Weaveworks Principal Engineer.

Fixes #602