### PR TITLE
Setting up instance label for Runner pods

### DIFF
--- a/controllers/tc000260_runner_pod_test.go
+++ b/controllers/tc000260_runner_pod_test.go
@@ -26,6 +26,7 @@ func Test_000260_runner_pod_test(t *testing.T) {
 		sourceName         = "runner-pod-test"
 		serviceAccountName = "helloworld-tf-runner"
 		runnerPodImage     = "ghcr.io/weaveworks/tf-runner:test"
+		revision           = "v2.6@sha256:c7fd0cc69b924aa5f9a6928477311737e439ca1b9e444855b0377e8a8ec65bb5"
 	)
 
 	var stringMap = map[string]string{
@@ -68,7 +69,7 @@ func Test_000260_runner_pod_test(t *testing.T) {
 	g.Expect(spec.ServiceAccountName == serviceAccountName)
 	g.Expect(spec.Containers[0].Image == runnerPodImage)
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123")
+	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -82,6 +83,8 @@ func Test_000260_runner_pod_test(t *testing.T) {
 		}
 		return true
 	})
+
+	g.Expect(podTemplate.Labels["app.kubernetes.io/instance"]).To(Equal("tf-runner-c7fd0cc6"))
 }
 
 func Test_000260_runner_pod_test_env_vars(t *testing.T) {
@@ -92,6 +95,7 @@ func Test_000260_runner_pod_test_env_vars(t *testing.T) {
 		sourceName         = "runner-pod-test"
 		serviceAccountName = "helloworld-tf-runner"
 		runnerPodImage     = "ghcr.io/weaveworks/tf-runner:test"
+		revision           = "v2.6@sha256:c7fd0cc69b924aa5f9a6928477311737e439ca1b9e444855b0377e8a8ec65bb5"
 	)
 
 	var stringMap = map[string]string{
@@ -149,7 +153,7 @@ func Test_000260_runner_pod_test_env_vars(t *testing.T) {
 	g.Expect(spec.Containers[0].Env[3].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)
 	g.Expect(spec.Containers[0].Env[3].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123")
+	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -173,6 +177,7 @@ func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
 		sourceName         = "runner-pod-test"
 		serviceAccountName = "helloworld-tf-runner"
 		runnerPodImage     = "ghcr.io/weaveworks/tf-runner:test"
+		revision           = "v2.6@sha256:c7fd0cc69b924aa5f9a6928477311737e439ca1b9e444855b0377e8a8ec65bb5"
 	)
 
 	var stringMap = map[string]string{
@@ -239,7 +244,7 @@ func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
 	g.Expect(spec.Containers[0].Env[6].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)
 	g.Expect(spec.Containers[0].Env[6].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123")
+	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -263,6 +268,7 @@ func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
 		sourceName         = "runner-pod-test"
 		serviceAccountName = "helloworld-tf-runner"
 		runnerPodImage     = "ghcr.io/weaveworks/tf-runner:test"
+		revision           = "v2.6@sha256:c7fd0cc69b924aa5f9a6928477311737e439ca1b9e444855b0377e8a8ec65bb5"
 	)
 
 	var stringMap = map[string]string{
@@ -336,7 +342,7 @@ func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
 	g.Expect(spec.Containers[0].Env[2].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Name)
 	g.Expect(spec.Containers[0].Env[2].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Value)
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123")
+	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {

--- a/controllers/tc000260_runner_pod_test.go
+++ b/controllers/tc000260_runner_pod_test.go
@@ -66,8 +66,8 @@ func Test_000260_runner_pod_test(t *testing.T) {
 	}
 
 	spec := reconciler.runnerPodSpec(helloWorldTF, "runner.tls-123")
-	g.Expect(spec.ServiceAccountName == serviceAccountName)
-	g.Expect(spec.Containers[0].Image == runnerPodImage)
+	g.Expect(spec.ServiceAccountName).To(Equal(serviceAccountName))
+	g.Expect(spec.Containers[0].Image).To(Equal(runnerPodImage))
 
 	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
@@ -82,7 +82,7 @@ func Test_000260_runner_pod_test(t *testing.T) {
 			}
 		}
 		return true
-	})
+	}()).To(BeTrue())
 
 	g.Expect(podTemplate.Labels["app.kubernetes.io/instance"]).To(Equal("tf-runner-c7fd0cc6"))
 }
@@ -145,13 +145,14 @@ func Test_000260_runner_pod_test_env_vars(t *testing.T) {
 	}
 
 	spec := reconciler.runnerPodSpec(helloWorldTF, "runner.tls-123")
-	g.Expect(spec.ServiceAccountName == serviceAccountName)
-	g.Expect(spec.Containers[0].Image == runnerPodImage)
-	g.Expect(len(spec.Containers[0].Env) == 4)
-	g.Expect(spec.Containers[0].Env[2].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)
-	g.Expect(spec.Containers[0].Env[2].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)
-	g.Expect(spec.Containers[0].Env[3].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)
-	g.Expect(spec.Containers[0].Env[3].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)
+	g.Expect(spec.ServiceAccountName).To(Equal(serviceAccountName))
+	g.Expect(spec.Containers[0].Image).To(Equal(runnerPodImage))
+	g.Expect(len(spec.Containers[0].Env)).To(Equal(4))
+
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)))
 
 	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
@@ -166,7 +167,7 @@ func Test_000260_runner_pod_test_env_vars(t *testing.T) {
 			}
 		}
 		return true
-	})
+	}()).To(BeTrue())
 }
 
 func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
@@ -236,13 +237,14 @@ func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
 	}
 
 	spec := reconciler.runnerPodSpec(helloWorldTF, "runner.tls-123")
-	g.Expect(spec.ServiceAccountName == serviceAccountName)
-	g.Expect(spec.Containers[0].Image == runnerPodImage)
-	g.Expect(len(spec.Containers[0].Env) == 7)
-	g.Expect(spec.Containers[0].Env[5].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)
-	g.Expect(spec.Containers[0].Env[5].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)
-	g.Expect(spec.Containers[0].Env[6].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)
-	g.Expect(spec.Containers[0].Env[6].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)
+	g.Expect(spec.ServiceAccountName).To(Equal(serviceAccountName))
+	g.Expect(spec.Containers[0].Image).To(Equal(runnerPodImage))
+	g.Expect(len(spec.Containers[0].Env)).To(Equal(7))
+
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)))
 
 	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
@@ -257,7 +259,7 @@ func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
 			}
 		}
 		return true
-	})
+	}()).To(BeTrue())
 }
 
 func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
@@ -331,16 +333,16 @@ func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
 	}
 
 	spec := reconciler.runnerPodSpec(helloWorldTF, "runner.tls-123")
-	g.Expect(spec.ServiceAccountName == serviceAccountName)
-	g.Expect(spec.Containers[0].Image == runnerPodImage)
-	g.Expect(len(spec.Containers[0].Env) == 7)
-	g.Expect(spec.Containers[0].Env[5].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)
-	g.Expect(spec.Containers[0].Env[5].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)
-	g.Expect(spec.Containers[0].Env[6].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)
-	g.Expect(spec.Containers[0].Env[6].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)
+	g.Expect(spec.ServiceAccountName).To(Equal(serviceAccountName))
+	g.Expect(spec.Containers[0].Image).To(Equal(runnerPodImage))
+	g.Expect(len(spec.Containers[0].Env)).To(Equal(7))
 
-	g.Expect(spec.Containers[0].Env[2].Name == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Name)
-	g.Expect(spec.Containers[0].Env[2].Value == helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Value)
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[0].Value)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Name)))
+	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Value)))
 
 	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
 	g.Expect(func() bool {
@@ -355,7 +357,7 @@ func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
 			}
 		}
 		return true
-	})
+	}()).To(BeTrue())
 }
 
 func Test_000260_runner_pod_test_env_vars_proxy_output(t *testing.T) {

--- a/controllers/tc000260_runner_pod_test.go
+++ b/controllers/tc000260_runner_pod_test.go
@@ -69,7 +69,8 @@ func Test_000260_runner_pod_test(t *testing.T) {
 	g.Expect(spec.ServiceAccountName).To(Equal(serviceAccountName))
 	g.Expect(spec.Containers[0].Image).To(Equal(runnerPodImage))
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	podTemplate, err := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -154,7 +155,8 @@ func Test_000260_runner_pod_test_env_vars(t *testing.T) {
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)))
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)))
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	podTemplate, err := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -246,7 +248,8 @@ func Test_000260_runner_pod_test_env_vars_proxy(t *testing.T) {
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Name)))
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[1].Value)))
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	podTemplate, err := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {
@@ -344,7 +347,8 @@ func Test_000260_runner_pod_test_env_vars_proxy_overwrite(t *testing.T) {
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Name", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Name)))
 	g.Expect(spec.Containers[0].Env).Should(ContainElements(HaveField("Value", helloWorldTF.Spec.RunnerPodTemplate.Spec.Env[2].Value)))
 
-	podTemplate := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	podTemplate, err := runnerPodTemplate(helloWorldTF, "runner.tls-123", revision)
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(func() bool {
 		for k, v := range stringMap {
 			if v != podTemplate.ObjectMeta.Labels[k] {

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -283,7 +283,7 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Create Runner Pod.
 	// Wait for the Runner Pod to start.
 	traceLog.Info("Fetch/Create Runner pod for this Terraform resource")
-	runnerClient, closeConn, err := r.LookupOrCreateRunner(ctx, terraform)
+	runnerClient, closeConn, err := r.LookupOrCreateRunner(ctx, terraform, sourceObj.GetArtifact().Revision)
 	if err != nil {
 		log.Error(err, "unable to lookup or create runner")
 		if closeConn != nil {


### PR DESCRIPTION
closes #547 

- Setting the `app.kubernetes.io/instance` label to `tf-runner-<short-rev>` to avoid hitting label size limits
- Fixing some tests assertions
