### PR TITLE
feat: detect terraform object changes and publish generated plans

### DIFF
--- a/internal/git/provider/github_provider.go
+++ b/internal/git/provider/github_provider.go
@@ -1,0 +1,16 @@
+package provider
+
+import "golang.org/x/net/context"
+
+type GitHubProvider struct{}
+
+func (p GitHubProvider) ListPullRequests(ctx context.Context, repo Repository) (_ []PullRequest) {
+	panic("not implemented") // TODO: Implement
+}
+func (p GitHubProvider) AddCommentToPullREquest(ctx context.Context, repo PullRequest, comment []byte) {
+	panic("not implemented") // TODO: Implement
+}
+
+func newGitHubProvider() GitHubProvider {
+	return GitHubProvider{}
+}

--- a/internal/git/provider/provider.go
+++ b/internal/git/provider/provider.go
@@ -1,0 +1,21 @@
+package provider
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+)
+
+type Provider interface {
+	ListPullRequests(ctx context.Context, repo Repository) []PullRequest
+	AddCommentToPullREquest(ctx context.Context, repo PullRequest, comment []byte)
+}
+
+func New(provider string) (Provider, error) {
+	switch provider {
+	case "github":
+		return newGitHubProvider(), nil
+	default:
+		return nil, fmt.Errorf("unknown provider: %s", provider)
+	}
+}

--- a/internal/git/provider/pull_request.go
+++ b/internal/git/provider/pull_request.go
@@ -1,0 +1,7 @@
+package provider
+
+type PullRequest struct {
+	Repository Repository
+	BaseBranch string
+	HeadBranch string
+}

--- a/internal/git/provider/repo.go
+++ b/internal/git/provider/repo.go
@@ -1,0 +1,7 @@
+package provider
+
+type Repository struct {
+	Project string
+	Org     string
+	Name    string
+}

--- a/internal/server/webhook/options.go
+++ b/internal/server/webhook/options.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Option func(s *Server) error
@@ -33,6 +34,14 @@ func WithListenAddress(addr string) Option {
 func WithListener(listener net.Listener) Option {
 	return func(s *Server) error {
 		s.listener = listener
+
+		return nil
+	}
+}
+
+func WithClusterClient(clusterClient client.Client) Option {
+	return func(s *Server) error {
+		s.clusterClient = clusterClient
 
 		return nil
 	}

--- a/internal/server/webhook/server.go
+++ b/internal/server/webhook/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
@@ -16,8 +17,9 @@ const (
 )
 
 type Server struct {
-	log      logr.Logger
-	listener net.Listener
+	log           logr.Logger
+	listener      net.Listener
+	clusterClient client.Client
 }
 
 func New(options ...Option) (*Server, error) {


### PR DESCRIPTION
What it does:
Implements a simplified version of the informer to watch Terraform objects and detect if we have new Plan output available, then publish it as a comment on a PR.

What it doesn't do:
 * Deeper filtering for example "is the plan still has mark it's pending".
 * The "publish comment" part is a dummy interface. It will be mostly code from WGE with multiple git providers[^1], and just add missing behaviour.

[^1]: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/pkg/git

Closes #605

References:
* https://github.com/weaveworks/weave-gitops-enterprise/tree/main/pkg/git