### PR TITLE
Changing output type sufix to __type

### DIFF
--- a/controllers/tc000061_vars_hcl_input_test.go
+++ b/controllers/tc000061_vars_hcl_input_test.go
@@ -143,26 +143,26 @@ func Test_000061_vars_hcl_input_test(t *testing.T) {
 		"Name":      "tf-output-" + terraformName,
 		"Namespace": "flux-system",
 		"Values": map[string]string{
-			"cluster_id":      "eu-test-1:stg:winter-squirrel",
-			"active":          "true",
-			"active.type":     `"bool"`,
-			"node_count":      "10",
-			"node_count.type": `"number"`,
-			"azs":             "[\n      \"eu-test-1a\",\n      \"eu-test-1b\",\n      \"eu-test-1c\"\n    ]",
-			"azs.type":        "[\n      \"list\",\n      \"string\"\n    ]",
+			"cluster_id":       "eu-test-1:stg:winter-squirrel",
+			"active":           "true",
+			"active__type":     `"bool"`,
+			"node_count":       "10",
+			"node_count__type": `"number"`,
+			"azs":              "[\n      \"eu-test-1a\",\n      \"eu-test-1b\",\n      \"eu-test-1c\"\n    ]",
+			"azs__type":        "[\n      \"list\",\n      \"string\"\n    ]",
 		},
 		"OwnerRef[0]": string(createdHelloWorldTF.UID),
 	}
 	g.Eventually(func() (map[string]interface{}, error) {
 		err := k8sClient.Get(ctx, outputKey, &outputSecret)
 		values := map[string]string{
-			"cluster_id":      string(outputSecret.Data["cluster_id"]),
-			"active":          string(outputSecret.Data["active"]),
-			"active.type":     string(outputSecret.Data["active.type"]),
-			"node_count":      string(outputSecret.Data["node_count"]),
-			"node_count.type": string(outputSecret.Data["node_count.type"]),
-			"azs":             string(outputSecret.Data["azs"]),
-			"azs.type":        string(outputSecret.Data["azs.type"]),
+			"cluster_id":       string(outputSecret.Data["cluster_id"]),
+			"active":           string(outputSecret.Data["active"]),
+			"active__type":     string(outputSecret.Data["active__type"]),
+			"node_count":       string(outputSecret.Data["node_count"]),
+			"node_count__type": string(outputSecret.Data["node_count__type"]),
+			"azs":              string(outputSecret.Data["azs"]),
+			"azs__type":        string(outputSecret.Data["azs__type"]),
 		}
 		return map[string]interface{}{
 			"Name":        outputSecret.Name,

--- a/controllers/tf_controller_outputs.go
+++ b/controllers/tf_controller_outputs.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"sort"
 	"strings"
+
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
@@ -165,7 +166,7 @@ func (r *TerraformReconciler) writeOutput(ctx context.Context, terraform infrav1
 			data[outputOrAlias] = []byte(cv.AsString())
 		} else {
 			data[outputOrAlias] = outputMeta.Value
-			data[outputOrAlias+".type"] = outputMeta.Type
+			data[outputOrAlias+"__type"] = outputMeta.Type
 		}
 	}
 


### PR DESCRIPTION
closes #545 

- changing output type info sufix from `.type` to `__type` to avoid the `kustomization-controller` freak out when it sees any variable with a `.` in it.