### PR TITLE
Use SetLogger early in branch-based-planner/main.go to avoid a (near) panic

### DIFF
--- a/cmd/branch-based-planner/main.go
+++ b/cmd/branch-based-planner/main.go
@@ -35,6 +35,7 @@ func main() {
 	log := logger.
 		NewLogger(opts.logOptions).
 		WithValues("version", BuildVersion, "sha", BuildSHA)
+	logger.SetLogger(log)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 


### PR DESCRIPTION
When using github.com/fluxcd/pkg/runtime/logger, the advice is to call `SetLogger()` as soon as you've constructed a log. Doing so avoids a panic from controller-runtime, which complains its own `SetLogger` was not called.

This appears -- admittedly, with very few data points -- to be less of a problem prior to #672. I'm not sure why, possibly there is a race between something provoking controller-runtime to sort itself out. I'm not too bothered finding out why, this time, because calling `SetLogger(...)` early and explicitly is better in any case.
