### PR TITLE
Add --no-cross-namespace-refs to branch-based-planner

### DIFF
--- a/cmd/branch-planner/flags.go
+++ b/cmd/branch-planner/flags.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/logger"
 	flag "github.com/spf13/pflag"
+
 	"github.com/weaveworks/tf-controller/internal/server/polling"
 )
 
@@ -15,6 +17,7 @@ type applicationOptions struct {
 	branchPollingInterval time.Duration
 
 	logOptions logger.Options
+	aclOptions acl.Options
 
 	runtimeNamespace   string
 	watchAllNamespaces bool
@@ -37,6 +40,7 @@ func parseFlags() *applicationOptions {
 		"Interval to use for PR branch sources (default is to use the value of --polling-interval).")
 
 	opts.logOptions.BindFlags(flag.CommandLine)
+	opts.aclOptions.BindFlags(flag.CommandLine)
 
 	flag.Parse()
 

--- a/cmd/branch-planner/polling.go
+++ b/cmd/branch-planner/polling.go
@@ -16,6 +16,7 @@ func startPollingServer(ctx context.Context, log logr.Logger, clusterClient clie
 		polling.WithConfigMap(opts.pollingConfigMap),
 		polling.WithPollingInterval(opts.pollingInterval),
 		polling.WithBranchPollingInterval(opts.branchPollingInterval),
+		polling.WithNoCrossNamespaceRefs(opts.aclOptions.NoCrossNamespaceRefs),
 	)
 	if err != nil {
 		return fmt.Errorf("problem configuring the polling server: %w", err)

--- a/internal/server/polling/option.go
+++ b/internal/server/polling/option.go
@@ -58,3 +58,10 @@ func WithBranchPollingInterval(interval time.Duration) Option {
 		return nil
 	}
 }
+
+func WithNoCrossNamespaceRefs(deny bool) Option {
+	return func(s *Server) error {
+		s.noCrossNamespaceRefs = deny
+		return nil
+	}
+}

--- a/internal/server/polling/server.go
+++ b/internal/server/polling/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	configMapRef          client.ObjectKey
 	pollingInterval       time.Duration
 	branchPollingInterval time.Duration
+	noCrossNamespaceRefs  bool
 }
 
 func New(options ...Option) (*Server, error) {


### PR DESCRIPTION
The standard for Flux-source-integrating controllers is to include a flag `--no-cross-namespace-refs` for disabling cross-namespace access to sources. This commit adds the flag, and implements the ban when it's set.

This also fixes a bug whereby the namespace of the sourceRef was not defaulted to the namespace of the Terraform object containing it; so, if you left it out, the client.Get() for the source would fail.
