### PR TITLE
Add --no-cross-namespace-refs to tf-controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaveworks/tf-controller/mtls"
 	"github.com/weaveworks/tf-controller/runner"
 
+	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/client"
 	runtimeCtrl "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
@@ -90,6 +91,7 @@ func main() {
 		runnerGRPCMaxMessageSize int
 		allowBreakTheGlass       bool
 		clusterDomain            string
+		aclOptions               acl.Options
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -115,6 +117,7 @@ func main() {
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
+	aclOptions.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(logger.NewLogger(logOptions))
@@ -195,6 +198,7 @@ func main() {
 		RunnerGRPCMaxMessageSize: runnerGRPCMaxMessageSize,
 		AllowBreakTheGlass:       allowBreakTheGlass,
 		ClusterDomain:            clusterDomain,
+		NoCrossNamespaceRefs:     aclOptions.NoCrossNamespaceRefs,
 	}
 
 	if err = reconciler.SetupWithManager(mgr, concurrent, httpRetry); err != nil {

--- a/controllers/tc000015_source_cross_ns_denied_test.go
+++ b/controllers/tc000015_source_cross_ns_denied_test.go
@@ -1,0 +1,96 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_000015_cross_namespace_source_denied_test(t *testing.T) {
+	Spec("This spec describes the behaviour of a Terraform resource when source is in another namespace and cross-namespace refs are not allowed.")
+	It("should be reconciled to have a Source error.")
+
+	By("setting the reconciler to disallow cross-namespace refs")
+	defer func(original bool) {
+		reconciler.NoCrossNamespaceRefs = original
+	}(reconciler.NoCrossNamespaceRefs)
+	reconciler.NoCrossNamespaceRefs = true
+
+	const (
+		sourceName    = "gr-source"
+		terraformName = "tf-cross-ns"
+	)
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	Given("a GitRepository")
+	By("defining a new GitRepository resource.")
+	testRepo := sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceName,
+			Namespace: "flux-system",
+		},
+		Spec: sourcev1.GitRepositorySpec{
+			URL: "https://github.com/openshift-fluxv2-poc/podinfo",
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "master",
+			},
+			Interval: metav1.Duration{Duration: time.Second * 30},
+		},
+	}
+	By("creating the GitRepository resource in the cluster.")
+	It("should be created successfully.")
+	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
+	t.Cleanup(func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) })
+
+	Given("a Terraform resource, attached to a GitRepository resource in another namespace.")
+	By("creating a new TF resource and attaching to the repo via `sourceRef`.")
+	helloWorldTF := infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      terraformName,
+			Namespace: "default",
+		},
+		Spec: infrav1.TerraformSpec{
+			ApprovePlan: "auto",
+			Path:        "./terraform-hello-world-example",
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Kind:      "GitRepository",
+				Name:      sourceName,
+				Namespace: "flux-system",
+			},
+			Interval: metav1.Duration{Duration: time.Second * 10},
+		},
+	}
+	It("should be created and attached successfully.")
+	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
+	t.Cleanup(func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) })
+
+	It("should be access denied error.")
+	By("checking that the Ready's reason of the TF resource become `ArtifactFailed`.")
+
+	helloWorldTFKey := client.ObjectKeyFromObject(&helloWorldTF)
+	var readyCondition *metav1.Condition
+	g.Eventually(func() interface{} {
+		var createdHelloWorldTF infrav1.Terraform
+		g.Expect(k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)).To(Succeed())
+		conditions := createdHelloWorldTF.Status.Conditions
+		readyCondition = meta.FindStatusCondition(conditions, "Ready")
+		return readyCondition
+	}, timeout, interval).ShouldNot(BeNil())
+
+	g.Expect(*readyCondition).To(
+		gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Type":    Equal("Ready"),
+			"Reason":  Equal(infrav1.ArtifactFailedReason),
+			"Message": Equal("Source 'GitRepository/flux-system/gr-source' access denied"),
+		}))
+}


### PR DESCRIPTION
The Flux convention is to use the flag --no-cross-reference-refs (as encoded in github.com/fluxcd/pkg/acl) to deny cross-namespace references, thereby closing a potential security hole.

This commit adds support for the flag to the controller, and a test that it does indeed ban cross-namespace refs.
