### PR TITLE
Handle the list of Pull Requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,3 +40,4 @@ jobs:
           make TARGET="^Test_000[12]"  target-test
           make TARGET="^Test_0003"     target-test
           make TARGET="^Test_0099"     target-test
+          make test-internal

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ test: manifests generate download-crd-deps fmt vet envtest api-docs ## Run tests
 target-test: manifests generate download-crd-deps fmt vet envtest api-docs ## Run tests. e.g make TARGET=250 target-test
 	$(TEST_SETTINGS) go test ./controllers -coverprofile cover.out -v -run $(TARGET)
 
+.PHONY: test-internal
+test-internal: manifests generate download-crd-deps fmt vet envtest api-docs ## Run tests in the internal directory.
+	$(TEST_SETTINGS) go test ./internal/... -coverprofile cover.out -v
+
 .PHONY: gen-grpc
 gen-grpc:
 	env PATH=$(shell pwd)/bin:$$PATH $(PROJECT_DIR)/bin/protoc --go_out=. --go_opt=Mrunner/runner.proto=runner/ --go-grpc_out=. --go-grpc_opt=Mrunner/runner.proto=runner/ runner/runner.proto

--- a/cmd/branch-based-planner/flags.go
+++ b/cmd/branch-based-planner/flags.go
@@ -10,8 +10,9 @@ import (
 )
 
 type applicationOptions struct {
-	pollingConfigMap string
-	pollingInterval  time.Duration
+	pollingConfigMap      string
+	pollingInterval       time.Duration
+	branchPollingInterval time.Duration
 
 	logOptions logger.Options
 
@@ -29,11 +30,19 @@ func parseFlags() *applicationOptions {
 
 	flag.DurationVar(&opts.pollingInterval,
 		"polling-interval", polling.DefaultPollingInterval,
-		"Wait between two request to the same Terraform object.")
+		"Wait between two requests to the same Terraform object.")
+
+	flag.DurationVar(&opts.branchPollingInterval,
+		"branch-polling-interval", 0,
+		"Interval to use for PR branch sources (default is to use the value of --polling-interval).")
 
 	opts.logOptions.BindFlags(flag.CommandLine)
 
 	flag.Parse()
+
+	if opts.branchPollingInterval == 0 {
+		opts.branchPollingInterval = opts.pollingInterval
+	}
 
 	opts.runtimeNamespace = os.Getenv("RUNTIME_NAMESPACE")
 

--- a/cmd/branch-based-planner/polling.go
+++ b/cmd/branch-based-planner/polling.go
@@ -15,6 +15,7 @@ func startPollingServer(ctx context.Context, log logr.Logger, clusterClient clie
 		polling.WithClusterClient(clusterClient),
 		polling.WithConfigMap(opts.pollingConfigMap),
 		polling.WithPollingInterval(opts.pollingInterval),
+		polling.WithBranchPollingInterval(opts.branchPollingInterval),
 	)
 	if err != nil {
 		return fmt.Errorf("problem configuring the polling server: %w", err)

--- a/controllers/tf_controller_finalizer.go
+++ b/controllers/tf_controller_finalizer.go
@@ -87,13 +87,13 @@ func (r *TerraformReconciler) finalize(ctx context.Context, terraform infrav1.Te
 			traceLog.Info("Check for error")
 			if err != nil {
 				traceLog.Error(err, "Error, requeue job")
-				return terraform,controllerruntime.Result{Requeue: true}, err
+				return terraform, controllerruntime.Result{Requeue: true}, err
 			}
 
 			traceLog.Info("Patch status of the Terraform resource")
 			if err := r.patchStatus(ctx, objectKey, terraform.Status); err != nil {
 				log.Error(err, "unable to update status after applying")
-				return terraform,controllerruntime.Result{Requeue: true}, err
+				return terraform, controllerruntime.Result{Requeue: true}, err
 			}
 
 			traceLog.Info("Check for a nil error")

--- a/internal/informer/bbp/informer.go
+++ b/internal/informer/bbp/informer.go
@@ -90,25 +90,19 @@ func (i *Informer) SetDeleteHandler(fn func(interface{})) {
 }
 
 const (
-	AnnotationKey   = "terraform-conrtoller/branch-based-planner"
-	AnnotationValue = "true"
+	LabelKey            = "infra.weave.works/branch-based-planner"
+	LabelValue          = "true"
+	LabelPRIDKey string = "infra.weave.works/pr-id"
 )
 
 func (i *Informer) addHandler(obj interface{}) {}
 
-func (i *Informer) updateHandler(oldObj, newObj interface{}) {
+func (i *Informer) updateHandler(_, newObj interface{}) {
 	if !i.synced {
 		return
 	}
 	i.mux.RLock()
 	defer i.mux.RUnlock()
-
-	previous, ok := oldObj.(*tfv1alpha2.Terraform)
-	if !ok {
-		i.log.Info("previous object is not a Terraform object", "object", oldObj)
-
-		return
-	}
 
 	current, ok := newObj.(*tfv1alpha2.Terraform)
 	if !ok {
@@ -117,7 +111,7 @@ func (i *Informer) updateHandler(oldObj, newObj interface{}) {
 		return
 	}
 
-	if previous.Annotations[AnnotationKey] != AnnotationValue || current.Annotations[AnnotationKey] != AnnotationValue {
+	if current.Labels[LabelKey] != LabelValue {
 		i.log.Info("Terraform object is not managed by the branch-based planner")
 
 		return

--- a/internal/server/polling/option.go
+++ b/internal/server/polling/option.go
@@ -64,3 +64,11 @@ func WithPollingInterval(interval time.Duration) Option {
 		return nil
 	}
 }
+
+func WithBranchPollingInterval(interval time.Duration) Option {
+	return func(s *Server) error {
+		s.branchPollingInterval = interval
+
+		return nil
+	}
+}

--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,57 +22,241 @@ func Test_poll_empty(t *testing.T) {
 
 	// Create a source for the Terraform object to point to
 	source := &sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "original-source",
+			Namespace: ns.Name,
+		},
 		Spec: sourcev1.GitRepositorySpec{
 			URL: "https://github.com/weaveworks/tf-controller",
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "main",
+			},
 		},
 	}
-	source.SetName("original-source")
-	source.SetNamespace(ns.GetName())
 	expectToSucceed(g, k8sClient.Create(context.TODO(), source))
 
-	// Create a Terraform object to be the template
+	// Create a Terraform object to be the template.
 	original := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "original",
+			Namespace: ns.Name,
+		},
 		Spec: infrav1.TerraformSpec{
 			SourceRef: infrav1.CrossNamespaceSourceReference{
-				Name: source.GetName(),
+				Name: source.Name,
 				Kind: "GitRepository",
 			},
 		},
 	}
-	original.SetNamespace(ns.GetName())
-	original.SetName("original")
 	expectToSucceed(g, k8sClient.Create(context.TODO(), original))
 
 	// This fakes a provider for the server to use.
 	var prs []provider.PullRequest
 
-	// Only WithClusterClient is really needed; the unexported option
-	// lets us supply the fake provider.
 	server, err := New(
 		WithClusterClient(k8sClient),
 	)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Now we'll run `poll` to step the server once, and afterwards,
+	// Now we'll run `reconcile` to step the server once, and afterwards,
 	// we should be able to see what it did.
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	server.reconcile(ctx, original, source, prs)
+	expectToSucceed(g, server.reconcile(ctx, original, source, prs))
 
 	// We expect it to have done nothing! So, check it didn't create
 	// any more Terraform or source objects.
-	var list infrav1.TerraformList
-	expectToSucceed(g, k8sClient.List(context.TODO(), &list, &client.ListOptions{
-		Namespace: ns.GetName(),
+	var tfList infrav1.TerraformList
+	expectToSucceed(g, k8sClient.List(context.TODO(), &tfList, &client.ListOptions{
+		Namespace: ns.Name,
 	}))
-	expectToEqual(g, len(list.Items), 1) // just the original
-	expectToEqual(g, list.Items[0].GetName(), original.GetName())
+	expectToEqual(g, len(tfList.Items), 1) // just the original
+	expectToEqual(g, tfList.Items[0].Name, original.Name)
 
-	var srclist sourcev1.GitRepositoryList
-	expectToSucceed(g, k8sClient.List(context.TODO(), &srclist, &client.ListOptions{
-		Namespace: ns.GetName(),
+	var srcList sourcev1.GitRepositoryList
+	expectToSucceed(g, k8sClient.List(context.TODO(), &srcList, &client.ListOptions{
+		Namespace: ns.Name,
 	}))
-	expectToEqual(g, len(list.Items), 1) // just `source`
+	expectToEqual(g, len(srcList.Items), 1) // just `source`
+	expectToEqual(g, srcList.Items[0].Name, source.Name)
+
+	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
+}
+
+// This checks that branch Terraform objects are created,
+// when there are open pull requests,
+// updated when the original Terraform object is updated,
+// and deleted when the corresponding PRs are closed.
+// The original Terraform object and source should be retained.
+func Test_poll_reconcile_objects(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ns := newNamespace(g)
+
+	// Create a source for the Terraform object to point to
+	source := &sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "original-source",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"test-label": "123",
+			},
+		},
+		Spec: sourcev1.GitRepositorySpec{
+			URL: "https://github.com/tf-controller/helloworld",
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "main",
+			},
+		},
+	}
+	expectToSucceed(g, k8sClient.Create(context.TODO(), source))
+
+	// Create a Terraform object to be the template.
+	original := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "original",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"test-label": "abc",
+			},
+		},
+		Spec: infrav1.TerraformSpec{
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Name: source.Name,
+				Kind: "GitRepository",
+			},
+			WriteOutputsToSecret: &infrav1.WriteOutputsToSecretSpec{
+				Name: "test-secret",
+			},
+		},
+	}
+	expectToSucceed(g, k8sClient.Create(context.TODO(), original))
+
+	// This fakes a provider for the server to use.
+	repo := provider.Repository{
+		Project: "fake-project",
+		Org:     "fake-org",
+		Name:    "fake-name",
+	}
+	prs := []provider.PullRequest{
+		{
+			Repository: repo,
+			Number:     1,
+			BaseBranch: "main",
+			HeadBranch: "test-branch-1",
+		},
+		{
+			Repository: repo,
+			Number:     2,
+			BaseBranch: "main",
+			HeadBranch: "test-branch-2",
+		},
+		{
+			Repository: repo,
+			Number:     3,
+			BaseBranch: "main",
+			HeadBranch: "test-branch-3",
+		},
+	}
+
+	server, err := New(
+		WithClusterClient(k8sClient),
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Now we'll run `reconcile` to step the server once, and afterwards,
+	// we should be able to see what it did.
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	expectToSucceed(g, server.reconcile(ctx, original, source, prs))
+
+	// We expect the branch TF objects and corresponding sources
+	// to be created for each PR
+	// and the original object and source to be retained.
+
+	// Check that the Terraform objects are created with expected fields.
+	var tfList infrav1.TerraformList
+	expectToSucceed(g, k8sClient.List(context.TODO(), &tfList, &client.ListOptions{
+		Namespace: ns.Name,
+	}))
+
+	expectToEqual(g, len(tfList.Items), 4)
+	expectToEqual(g, tfList.Items[0].Name, original.Name)
+	expectToEqual(g, tfList.Items[2].Name, original.Name+"-test-branch-2-2")
+
+	expectToEqual(g, tfList.Items[1].Spec.SourceRef.Name, "original-source-test-branch-1-1")
+	expectToEqual(g, tfList.Items[1].Spec.SourceRef.Namespace, ns.Name)
+	expectToEqual(g, tfList.Items[1].Spec.PlanOnly, true)
+	expectToEqual(g, tfList.Items[1].Spec.StoreReadablePlan, "human")
+	expectToEqual(g, tfList.Items[1].Spec.WriteOutputsToSecret.Name, "test-secret-test-branch-1-1")
+
+	expectToEqual(g, tfList.Items[3].Labels["infra.weave.works/branch-based-planner"], "true")
+	expectToEqual(g, tfList.Items[3].Labels["infra.weave.works/pr-id"], "3")
+	expectToEqual(g, tfList.Items[3].Labels["test-label"], "abc")
+
+	// Check that the Source objects are created with all expected fields.
+	var srcList sourcev1.GitRepositoryList
+	expectToSucceed(g, k8sClient.List(context.TODO(), &srcList, &client.ListOptions{
+		Namespace: ns.Name,
+	}))
+
+	expectToEqual(g, len(srcList.Items), 4)
+	expectToEqual(g, srcList.Items[0].Name, source.Name)
+	expectToEqual(g, srcList.Items[2].Name, source.Name+"-test-branch-2-2")
+
+	expectToEqual(g, srcList.Items[1].Spec.Reference.Branch, "test-branch-1")
+
+	expectToEqual(g, srcList.Items[3].Labels["infra.weave.works/branch-based-planner"], "true")
+	expectToEqual(g, srcList.Items[3].Labels["infra.weave.works/pr-id"], "3")
+	expectToEqual(g, srcList.Items[3].Labels["test-label"], "123")
+
+	// Check that branch Terraform objects are updated
+	// after the original Terraform object is updated.
+	original.Labels["test-label"] = "xyz"
+	original.Spec.WriteOutputsToSecret.Name = "new-test-secret"
+
+	expectToSucceed(g, k8sClient.Update(context.TODO(), original))
+	expectToSucceed(g, server.reconcile(ctx, original, source, prs))
+
+	tfList.Items = nil
+
+	expectToSucceed(g, k8sClient.List(context.TODO(), &tfList, &client.ListOptions{
+		Namespace: ns.Name,
+	}))
+
+	expectToEqual(g, tfList.Items[0].Name, original.Name)
+	expectToEqual(g, tfList.Items[0].Labels["test-label"], "xyz")
+	expectToEqual(g, tfList.Items[0].Spec.WriteOutputsToSecret.Name, "new-test-secret")
+
+	expectToEqual(g, tfList.Items[2].Name, original.Name+"-test-branch-2-2")
+	expectToEqual(g, tfList.Items[2].Labels["test-label"], "xyz")
+	expectToEqual(g, tfList.Items[2].Spec.WriteOutputsToSecret.Name, "new-test-secret-test-branch-2-2")
+
+	// Check that corresponding Terraform objects and Sources are deleted
+	// after PRs are deleted
+	// and the original Terraform object and source are retained.
+	prs = prs[2:]
+
+	expectToSucceed(g, server.reconcile(ctx, original, source, prs))
+
+	tfList.Items = nil
+
+	expectToSucceed(g, k8sClient.List(context.TODO(), &tfList, &client.ListOptions{
+		Namespace: ns.Name,
+	}))
+
+	expectToEqual(g, len(tfList.Items), 2)
+	expectToEqual(g, tfList.Items[0].Name, original.Name)
+	expectToEqual(g, tfList.Items[1].Name, original.Name+"-test-branch-3-3")
+
+	srcList.Items = nil
+
+	expectToSucceed(g, k8sClient.List(context.TODO(), &srcList, &client.ListOptions{
+		Namespace: ns.Name,
+	}))
+
+	expectToEqual(g, len(srcList.Items), 2)
+	expectToEqual(g, srcList.Items[0].Name, source.Name)
+	expectToEqual(g, srcList.Items[1].Name, source.Name+"-test-branch-3-3")
 
 	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -3,24 +3,48 @@ package polling
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
-	"github.com/weaveworks/tf-controller/api/v1alpha2"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/internal/informer/bbp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sLabels "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (s *Server) getTerraform(ctx context.Context, ref client.ObjectKey) (*v1alpha2.Terraform, error) {
-	obj := &v1alpha2.Terraform{}
-	err := s.clusterClient.Get(ctx, ref, obj)
-	if err != nil {
+func (s *Server) getTerraformObject(ctx context.Context, ref client.ObjectKey) (*infrav1.Terraform, error) {
+	obj := &infrav1.Terraform{}
+	if err := s.clusterClient.Get(ctx, ref, obj); err != nil {
 		return nil, fmt.Errorf("unable to get Terraform: %w", err)
 	}
 
 	return obj, nil
 }
 
-func (s *Server) getSource(ctx context.Context, tf *v1alpha2.Terraform) (*sourcev1b2.GitRepository, error) {
+func (s *Server) listTerraformObjects(ctx context.Context, tf *infrav1.Terraform, labels map[string]string) ([]*infrav1.Terraform, error) {
+	tfList := &infrav1.TerraformList{}
+
+	if err := s.clusterClient.List(ctx, tfList,
+		client.MatchingLabelsSelector{
+			Selector: k8sLabels.Set(labels).AsSelector(),
+		},
+		client.InNamespace(tf.Namespace),
+	); err != nil {
+		return nil, fmt.Errorf("unable to list Terraform objects: %w", err)
+	}
+
+	result := make([]*infrav1.Terraform, len(tfList.Items))
+	for i := range tfList.Items {
+		result[i] = &tfList.Items[i]
+	}
+
+	return result, nil
+}
+
+func (s *Server) getSource(ctx context.Context, tf *infrav1.Terraform) (*sourcev1b2.GitRepository, error) {
 	if tf.Spec.SourceRef.Kind != sourcev1b2.GitRepositoryKind {
 		return nil, fmt.Errorf("branch based planner does not support source kind: %s", tf.Spec.SourceRef.Kind)
 	}
@@ -30,18 +54,140 @@ func (s *Server) getSource(ctx context.Context, tf *v1alpha2.Terraform) (*source
 		Name:      tf.Spec.SourceRef.Name,
 	}
 	obj := &sourcev1b2.GitRepository{}
-	err := s.clusterClient.Get(ctx, ref, obj)
-	if err != nil {
+	if err := s.clusterClient.Get(ctx, ref, obj); err != nil {
 		return nil, fmt.Errorf("unable to get Source: %w", err)
 	}
 
 	return obj, nil
 }
 
+func (s *Server) reconcileTerraform(ctx context.Context, originalTF *infrav1.Terraform, originalSource *sourcev1b2.GitRepository, branch string, prID string, interval time.Duration) error {
+	tfName := s.createObjectName(originalTF.Name, branch, prID)
+	msg := fmt.Sprintf("Terraform object %s in the namespace %s", tfName, originalTF.Namespace)
+	source, err := s.reconcileSource(ctx, originalSource, branch, prID, interval)
+	if err != nil {
+		return fmt.Errorf("unable to reconcile Source for %s: %w", msg, err)
+	}
+
+	tf := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tfName,
+			Namespace: originalTF.Namespace,
+		},
+	}
+	branchLabels := s.createLabels(originalTF.Labels, branch, prID)
+	branchSecretName := s.createObjectName(originalTF.Spec.WriteOutputsToSecret.Name, branch, prID)
+
+	op, err := controllerutil.CreateOrUpdate(ctx, s.clusterClient, tf, func() error {
+		spec := originalTF.Spec.DeepCopy()
+
+		spec.SourceRef.Name = source.Name
+		spec.SourceRef.Namespace = source.Namespace
+		spec.PlanOnly = true
+		spec.StoreReadablePlan = "human"
+		spec.WriteOutputsToSecret.Name = branchSecretName
+
+		tf.Spec = *spec
+
+		tf.SetLabels(branchLabels)
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("reconcile failed for %s: %w", msg, err)
+	} else if op != controllerutil.OperationResultNone {
+		s.log.Info(fmt.Sprintf("%s successfully reconciled", msg), "operation", op)
+	}
+
+	return nil
+}
+
+func (s *Server) reconcileSource(ctx context.Context, originalSource *sourcev1b2.GitRepository, branch string, prID string, interval time.Duration) (*sourcev1b2.GitRepository, error) {
+	sourceName := s.createObjectName(originalSource.Name, branch, prID)
+	msg := fmt.Sprintf("Source %s in the namespace %s", sourceName, originalSource.Namespace)
+	source := &sourcev1b2.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceName,
+			Namespace: originalSource.Namespace,
+		},
+		Spec: originalSource.Spec,
+	}
+	branchLabels := s.createLabels(originalSource.Labels, branch, prID)
+
+	op, err := controllerutil.CreateOrUpdate(ctx, s.clusterClient, source, func() error {
+		source.SetLabels(branchLabels)
+
+		spec := originalSource.Spec.DeepCopy()
+
+		spec.Reference.Branch = branch
+		spec.Interval = metav1.Duration{
+			Duration: interval,
+		}
+
+		source.Spec = *spec
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reconcile failed for %s: %w", msg, err)
+	} else if op != controllerutil.OperationResultNone {
+		s.log.Info(fmt.Sprintf("%s successfully reconciled", msg), "operation", op)
+	}
+
+	return source, nil
+}
+
+func (s *Server) createObjectName(name string, branch string, prID string) string {
+	return fmt.Sprintf("%s-%s-%s", name, branch, prID)
+}
+
+func (s *Server) createLabels(labels map[string]string, branch string, prID string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[bbp.LabelKey] = bbp.LabelValue
+	labels[bbp.LabelPRIDKey] = prID
+
+	return labels
+}
+
+func (s *Server) deleteTerraform(ctx context.Context, tf *infrav1.Terraform) error {
+	msg := fmt.Sprintf("Terraform %s in the namespace %s", tf.Name, tf.Namespace)
+
+	if err := s.deleteSource(ctx, tf); err != nil {
+		s.log.Error(err, fmt.Sprintf("unable to delete Source for %s", msg))
+	}
+
+	if err := s.clusterClient.Delete(ctx, tf); err != nil {
+		return fmt.Errorf("unable to delete %s: %w", msg, err)
+	}
+
+	s.log.Info(fmt.Sprintf("deleted %s", msg))
+
+	return nil
+}
+
+func (s *Server) deleteSource(ctx context.Context, tf *infrav1.Terraform) error {
+	source, err := s.getSource(ctx, tf)
+	if err != nil {
+		return fmt.Errorf("unable to get Source for Terraform %s in the namespace %s: %w", tf.Name, tf.Namespace, err)
+	}
+
+	msg := fmt.Sprintf("Source %s in the namespace %s", source.Name, source.Namespace)
+
+	if err := s.clusterClient.Delete(ctx, source); err != nil {
+		return fmt.Errorf("unable to delete %s: %w", msg, err)
+	}
+
+	s.log.Info(fmt.Sprintf("deleted %s", msg))
+
+	return nil
+}
+
 func (s *Server) getSecret(ctx context.Context, ref client.ObjectKey) (*corev1.Secret, error) {
 	obj := &corev1.Secret{}
-	err := s.clusterClient.Get(ctx, ref, obj)
-	if err != nil {
+	if err := s.clusterClient.Get(ctx, ref, obj); err != nil {
 		return nil, fmt.Errorf("unable to get Secret: %w", err)
 	}
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/tf-controller/issues/662
Closes https://github.com/weaveworks/tf-controller/issues/586

- Added the `createTerraform`, `createSource`, `createLabels`, and `createObjectName` methods.

- Added the `listTerraformObjects` method.

- Added the `deleteTerraform` and `deleteSource` methods.

- Reworked branch-based planner label keys and values.

- Added the `branchPollingInterval` flag.

- Added Terraform object and source reconciliation logic.

- Added the `reconcileTerraform` and `reconcileObjects` functions for Terraform object and source reconciliation.

- Added tests for creating, updating, and deleting objects during polling

- Added a new test target to run tests in the `internal` directory.

- Added running internal tests to the `test` workflow.
