### PR TITLE
patch: fix force-unlock with delete path by updating in terraform.Status.Lock.Pending terraform CR.

### DIFF
--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -391,7 +391,12 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	traceLog.Info("Check for deletion timestamp to finalize")
 	if !terraform.ObjectMeta.DeletionTimestamp.IsZero() {
 		traceLog.Info("Calling finalize function")
-		if result, err := r.finalize(ctx, terraform, runnerClient, sourceObj, reconciliationLoopID); err != nil {
+		if terraform, result, err := r.finalize(ctx, terraform, runnerClient, sourceObj, reconciliationLoopID); err != nil {
+			traceLog.Info("Patch the status of the Terraform resource")
+			if patchErr := r.patchStatus(ctx, req.NamespacedName, terraform.Status); err != nil {
+				log.Error(patchErr, "unable to update status after the finalize is complete")
+				return ctrl.Result{Requeue: true}, patchErr
+			}
 			return result, err
 		}
 	}

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -393,7 +393,7 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		traceLog.Info("Calling finalize function")
 		if terraform, result, err := r.finalize(ctx, terraform, runnerClient, sourceObj, reconciliationLoopID); err != nil {
 			traceLog.Info("Patch the status of the Terraform resource")
-			if patchErr := r.patchStatus(ctx, req.NamespacedName, terraform.Status); err != nil {
+			if patchErr := r.patchStatus(ctx, req.NamespacedName, terraform.Status); patchErr != nil {
 				log.Error(patchErr, "unable to update status after the finalize is complete")
 				return ctrl.Result{Requeue: true}, patchErr
 			}


### PR DESCRIPTION
finalize() routine updates terraform.Status.Lock.Pending in terraform CR on lock error.
Return updated terraform from routine finalize() so that it can be patched on lock error.

closes #560 
