### PR TITLE
Branch-planning test scaffold

### DIFF
--- a/internal/server/polling/main_test.go
+++ b/internal/server/polling/main_test.go
@@ -1,0 +1,62 @@
+package polling
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	k8sClient client.Client
+)
+
+// TestMain wraps all the other tests in this file by starting an
+// testEnv (Kubernetes API), and stopping it after the tests.
+func TestMain(m *testing.M) {
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		panic(err)
+	}
+	defer testEnv.Stop()
+
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		panic(err)
+	}
+	k8sClient = c
+
+	m.Run()
+}
+
+var (
+	nscounter atomic.Int32
+)
+
+// newNamespace creates a namespace in which to run a test. In
+// general, an individual test will want to create a namespace at its
+// start, use its name for any other objects it creates, and delete
+// the namespace afterward. Test_scaffold shows how to do this.
+func newNamespace(g Gomega) *corev1.Namespace {
+	num := nscounter.Add(1)
+	name := fmt.Sprintf("test-ns-%d", num)
+	ns := corev1.Namespace{}
+	ns.SetName(name)
+	g.ExpectWithOffset(1, k8sClient.Create(context.TODO(), &ns)).To(Succeed())
+	return &ns
+}
+
+// Minimal test to check the scaffolding works.
+func Test_scaffold(t *testing.T) {
+	g := NewWithT(t)
+	ns := newNamespace(g)
+	// here is where you'd create some objects in the namespace, as
+	// part of your test case.
+	t.Cleanup(func() { g.Expect(k8sClient.Delete(context.TODO(), ns)).To(Succeed()) })
+}

--- a/internal/server/polling/main_test.go
+++ b/internal/server/polling/main_test.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,20 +57,28 @@ var (
 // general, an individual test will want to create a namespace at its
 // start, use its name for any other objects it creates, and delete
 // the namespace afterward. Test_scaffold shows how to do this.
-func newNamespace(g Gomega) *corev1.Namespace {
+func newNamespace(g gomega.Gomega) *corev1.Namespace {
 	num := nscounter.Add(1)
 	name := fmt.Sprintf("test-ns-%d", num)
 	ns := corev1.Namespace{}
 	ns.SetName(name)
-	g.ExpectWithOffset(1, k8sClient.Create(context.TODO(), &ns)).To(Succeed())
+	g.ExpectWithOffset(1, k8sClient.Create(context.TODO(), &ns)).To(gomega.Succeed())
 	return &ns
+}
+
+func expectToSucceed(g gomega.Gomega, arg interface{}) {
+	g.ExpectWithOffset(1, arg).To(gomega.Succeed())
+}
+
+func expectToEqual(g gomega.Gomega, arg interface{}, expect interface{}) {
+	g.ExpectWithOffset(1, arg).To(gomega.Equal(expect))
 }
 
 // Minimal test to check the scaffolding works.
 func Test_scaffold(t *testing.T) {
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 	ns := newNamespace(g)
 	// here is where you'd create some objects in the namespace, as
 	// part of your test case.
-	t.Cleanup(func() { g.Expect(k8sClient.Delete(context.TODO(), ns)).To(Succeed()) })
+	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -1,0 +1,77 @@
+package polling
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/internal/git/provider"
+)
+
+// This checks poll can be called with a little setting-up, with no
+// result expected.
+func Test_poll_empty(t *testing.T) {
+	g := NewWithT(t)
+	ns := newNamespace(g)
+
+	// Create a source for the Terraform object to point to
+	source := &sourcev1.GitRepository{
+		Spec: sourcev1.GitRepositorySpec{
+			URL: "https://github.com/weaveworks/tf-controller",
+		},
+	}
+	source.SetName("original-source")
+	source.SetNamespace(ns.GetName())
+	g.Expect(k8sClient.Create(context.TODO(), source)).To(Succeed())
+
+	// Create a Terraform object to be the template
+	original := &infrav1.Terraform{
+		Spec: infrav1.TerraformSpec{
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Name: source.GetName(),
+				Kind: "GitRepository",
+			},
+		},
+	}
+	original.SetNamespace(ns.GetName())
+	original.SetName("original")
+	g.Expect(k8sClient.Create(context.TODO(), original)).To(Succeed())
+
+	// This fakes a provider for the server to use.
+	var prs []provider.PullRequest
+
+	// Only WithClusterClient is really needed; the unexported option
+	// lets us supply the fake provider.
+	server, err := New(
+		WithClusterClient(k8sClient),
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Now we'll run `poll` to step the server once, and afterwards,
+	// we should be able to see what it did.
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	server.reconcile(ctx, original, source, prs)
+
+	// We expect it to have done nothing! So, check it didn't create
+	// any more Terraform or source objects.
+	var list infrav1.TerraformList
+	g.Expect(k8sClient.List(context.TODO(), &list, &client.ListOptions{
+		Namespace: ns.GetName(),
+	})).To(Succeed())
+	g.Expect(len(list.Items)).To(Equal(1)) // just the original
+	g.Expect(list.Items[0].GetName()).To(Equal(original.GetName()))
+
+	var srclist sourcev1.GitRepositoryList
+	g.Expect(k8sClient.List(context.TODO(), &srclist, &client.ListOptions{
+		Namespace: ns.GetName(),
+	})).To(Succeed())
+	g.Expect(len(list.Items)).To(Equal(1)) // just `source`
+
+	t.Cleanup(func() { g.Expect(k8sClient.Delete(context.TODO(), ns)).To(Succeed()) })
+}


### PR DESCRIPTION
This adds a bit of scaffolding so that the branch-planning can be tested with

 - a real Kubernetes API (via envtest)
 - a fake git provider (via an option for injecting it when constructing the Server)

It also gives an example of testing the base case.
