### PR TITLE
fix pending plan not equal plan id in secret

### DIFF
--- a/api/planid/plain_id.go
+++ b/api/planid/plain_id.go
@@ -1,0 +1,54 @@
+package planid
+
+import (
+	"fmt"
+	"strings"
+)
+
+// getPlanIDv0 parses old revision format: master/b8e362c206e3d0cbb7ed22ced771a0056455a2fb
+func getPlanIDv0(revision string) string {
+	parts := strings.Split(revision, "/")
+	if len(parts) != 2 {
+		if len(revision) > 10 {
+			hash := revision[:10]
+			return "plan-" + hash
+		}
+		return "plan-" + revision
+	}
+
+	branch := parts[0]
+	hash := parts[1]
+	if len(hash) > 10 {
+		hash = hash[:10]
+	}
+
+	planID := "plan-" + branch + "-" + hash
+	return planID
+}
+
+// GetPlanID parses revision in ${branch}@${algo}:${hash}
+// to plan ID is plan-${branch}-${hash 10 digits}
+func GetPlanID(revision string) string {
+	parts := strings.Split(revision, "@")
+	if len(parts) != 2 {
+		return getPlanIDv0(revision)
+	}
+
+	branch := parts[0]
+
+	// parts[1] is now "${algo}:${hash}"
+	hashParts := strings.Split(parts[1], ":")
+	hash := hashParts[1]
+
+	if len(hash) > 10 {
+		hash = hash[:10]
+	}
+
+	planID := "plan-" + branch + "-" + hash
+	return planID
+}
+
+func GetApproveMessage(planId string, message string) string {
+	approveMessage := fmt.Sprintf("%s: set approvePlan: \"%s\" to approve this plan.", message, planId)
+	return approveMessage
+}

--- a/api/planid/plan_id_test.go
+++ b/api/planid/plan_id_test.go
@@ -1,0 +1,52 @@
+package planid
+
+import (
+	"testing"
+)
+
+func TestGetPlanID(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		want     string
+	}{
+		{
+			name:     "Valid hash more than 10 characters",
+			revision: "branch1@algo1:12345678901234567890",
+			want:     "plan-branch1-1234567890",
+		},
+		{
+			name:     "Valid hash equal to 10 characters",
+			revision: "branch2@algo2:1234567890",
+			want:     "plan-branch2-1234567890",
+		},
+		{
+			name:     "Valid hash less than 10 characters",
+			revision: "branch3@algo3:123456789",
+			want:     "plan-branch3-123456789",
+		},
+		{
+			name:     "Valid branch and hash",
+			revision: "branch4@algo4:abc123xyz",
+			want:     "plan-branch4-abc123xyz",
+		},
+		{
+			name:     "Valid old format",
+			revision: "main/12345678901234567890",
+			want:     "plan-main-1234567890",
+		},
+		{
+			name:     "Valid old format bucket format",
+			revision: "12345678901234567890",
+			want:     "plan-1234567890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPlanID(tt.revision); got != tt.want {
+				t.Errorf("GetPlanID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/tc000010_no_outputs_test.go
+++ b/controllers/tc000010_no_outputs_test.go
@@ -159,7 +159,7 @@ spec:
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -186,7 +186,7 @@ spec:
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	It("should have an available output.")

--- a/controllers/tc000011_workspace_no_outputs_test.go
+++ b/controllers/tc000011_workspace_no_outputs_test.go
@@ -160,7 +160,7 @@ spec:
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -187,7 +187,7 @@ spec:
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	It("should have an available output.")

--- a/controllers/tc000012_src_bucket_no_outputs_test.go
+++ b/controllers/tc000012_src_bucket_no_outputs_test.go
@@ -142,7 +142,7 @@ func Test_000012_src_bucket_no_outputs_test(t *testing.T) {
 	}))
 
 	It("should generate the Secret containing the plan named with the artifact revision")
-	By("checking that the Secret contains plan-822c3dd335579b435b5ada924d6f38b227412a5c in its labels.")
+	By("checking that the Secret contains plan-822c3dd335 in its labels.")
 	tfplanKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
 	tfplanSecret := corev1.Secret{}
 	g.Eventually(func() map[string]interface{} {
@@ -156,7 +156,7 @@ func Test_000012_src_bucket_no_outputs_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-822c3dd335579b435b5ada924d6f38b227412a5c",
+		"SavedPlan":             "plan-822c3dd335",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -183,7 +183,7 @@ func Test_000012_src_bucket_no_outputs_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-822c3dd335579b435b5ada924d6f38b227412a5c",
+		"LastAppliedPlan": "plan-822c3dd335",
 	}))
 
 	It("should have an available output.")

--- a/controllers/tc000030_plan_only_no_outputs_test.go
+++ b/controllers/tc000030_plan_only_no_outputs_test.go
@@ -141,7 +141,7 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":    infrav1.ConditionTypePlan,
 		"Reason":  "TerraformPlannedWithChanges",
-		"Pending": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Pending": "plan-master-b8e362c206",
 	}))
 
 	time.Sleep(5 * time.Second)
@@ -184,7 +184,7 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))

--- a/controllers/tc000031_plan_only_with_showplan_as_cm_no_outputs_test.go
+++ b/controllers/tc000031_plan_only_with_showplan_as_cm_no_outputs_test.go
@@ -142,7 +142,7 @@ func Test_000031_plan_only_with_showplan_as_cm_no_outputs_test(t *testing.T) {
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":    infrav1.ConditionTypePlan,
 		"Reason":  "TerraformPlannedWithChanges",
-		"Pending": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Pending": "plan-master-b8e362c206",
 	}))
 
 	It("should generate the Secret containing the plan named with branch and commit id.")
@@ -160,7 +160,7 @@ func Test_000031_plan_only_with_showplan_as_cm_no_outputs_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -179,7 +179,7 @@ func Test_000031_plan_only_with_showplan_as_cm_no_outputs_test(t *testing.T) {
 			"TFPlan":    tfplanCM.Data["tfplan"],
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan": "plan-master-b8e362c206",
 		"TFPlan": `
 Changes to Outputs:
   + hello_world = "Hello, World!"

--- a/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
+++ b/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
@@ -126,7 +126,7 @@ func Test_000050_plan_and_manual_approve_no_outputs_test(t *testing.T) {
 	}, timeout*3, interval).ShouldNot(BeZero())
 
 	Given("the plan id is the `plan` plus the branch name (master) plus the commit id.")
-	const planId = "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb"
+	const planId = "plan-master-b8e362c206"
 
 	By("checking that the planned status of the TF is created successfully.")
 	By("checking the reason is `TerraformPlannedWithChanges`.")

--- a/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
+++ b/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
@@ -126,7 +126,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 	}, timeout*3, interval).ShouldNot(BeZero())
 
 	Given("the plan id is the `plan` plus the branch name (master) plus the commit id.")
-	const planId = "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb"
+	const planId = "plan-master-b8e362c206"
 
 	By("checking that the planned status of the TF is created successfully.")
 	By("checking the reason is `TerraformPlannedWithChanges`.")
@@ -267,7 +267,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"LastAppliedPlan": "plan-master-ed22ced771",
 	}))
 	// TODO check Output condition
 

--- a/controllers/tc000052_plan_and_manual_approve_with_files_test.go
+++ b/controllers/tc000052_plan_and_manual_approve_with_files_test.go
@@ -150,7 +150,7 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 	}, timeout*3, interval).ShouldNot(BeZero())
 
 	Given("the plan id is the `plan` plus the branch name (master) plus the commit id.")
-	const planId = "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb"
+	const planId = "plan-master-b8e362c206"
 
 	By("checking that the planned status of the TF is created successfully.")
 	By("checking the reason is `TerraformPlannedWithChanges`.")

--- a/controllers/tc000100_applied_should_tx_to_plan_when_source_changed_test.go
+++ b/controllers/tc000100_applied_should_tx_to_plan_when_source_changed_test.go
@@ -129,7 +129,7 @@ func Test_000100_applied_resource_should_transit_back_to_plan_when_source_change
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":    infrav1.ConditionTypePlan,
 		"Reason":  "TerraformPlannedWithChanges",
-		"Pending": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Pending": "plan-master-b8e362c206",
 		"Message": "Plan generated",
 	}))
 
@@ -147,7 +147,7 @@ func Test_000100_applied_resource_should_transit_back_to_plan_when_source_change
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -175,7 +175,7 @@ func Test_000100_applied_resource_should_transit_back_to_plan_when_source_change
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 	// TODO check Output condition
 
@@ -249,8 +249,8 @@ func Test_000100_applied_resource_should_transit_back_to_plan_when_source_change
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypePlan,
 		"Reason":          "TerraformPlannedWithChanges",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"Pending":         "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"LastAppliedPlan": "plan-master-b8e362c206",
+		"Pending":         "plan-master-ed22ced771",
 	}))
 
 }

--- a/controllers/tc000110_auto_applied_should_tx_to_plan_then_apply_when_source_changed_test.go
+++ b/controllers/tc000110_auto_applied_should_tx_to_plan_then_apply_when_source_changed_test.go
@@ -129,7 +129,7 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":    infrav1.ConditionTypePlan,
 		"Reason":  "TerraformPlannedWithChanges",
-		"Pending": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Pending": "plan-master-b8e362c206",
 		"Message": "Plan generated",
 	}))
 
@@ -147,7 +147,7 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -175,7 +175,7 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 	// TODO check Output condition
 
@@ -240,7 +240,7 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"SavedPlan":   "plan-master-ed22ced771",
 		"TFPlanEmpty": false,
 	}))
 
@@ -265,7 +265,7 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"LastAppliedPlan": "plan-master-ed22ced771",
 		"Pending":         "",
 		"Message":         "Applied successfully",
 	}))

--- a/controllers/tc000121_destroy_on_delete_test.go
+++ b/controllers/tc000121_destroy_on_delete_test.go
@@ -179,7 +179,7 @@ func Test_000121_destroy_on_delete_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -206,7 +206,7 @@ func Test_000121_destroy_on_delete_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"Destroy?":        false,
 	}))
 
@@ -285,7 +285,7 @@ func Test_000121_destroy_on_delete_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))

--- a/controllers/tc000130_destroy_no_outputs_test.go
+++ b/controllers/tc000130_destroy_no_outputs_test.go
@@ -182,7 +182,7 @@ func Test_000130_destroy_no_outputs_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -209,7 +209,7 @@ func Test_000130_destroy_no_outputs_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"Destroy?":        false,
 	}))
 	// TODO check Output condition
@@ -278,7 +278,7 @@ func Test_000130_destroy_no_outputs_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Destroy applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"Destroy?":        true,
 	}))
 

--- a/controllers/tc000131_destroy_no_changes_test.go
+++ b/controllers/tc000131_destroy_no_changes_test.go
@@ -178,7 +178,7 @@ func Test_000131_destroy_no_changes_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -205,7 +205,7 @@ func Test_000131_destroy_no_changes_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"Destroy?":        false,
 	}))
 	// TODO check Output condition

--- a/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
+++ b/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
@@ -174,7 +174,7 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -200,7 +200,7 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 	// TODO check Output condition
 
@@ -307,7 +307,7 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"Pending":         "",
 		"Message":         "Applied successfully",
 	}))

--- a/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
+++ b/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
@@ -175,7 +175,7 @@ func Test_000150_manual_apply_should_report_and_loop_when_drift_detected_test(t 
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -204,7 +204,7 @@ func Test_000150_manual_apply_should_report_and_loop_when_drift_detected_test(t 
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 	// TODO check Output condition
 

--- a/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
+++ b/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
@@ -168,7 +168,7 @@ func Test_000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_te
 	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	By("checking that the config map payload got created.")
@@ -221,7 +221,7 @@ func Test_000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_te
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"SavedPlan":             "plan-master-ed22ced771",
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -253,7 +253,7 @@ func Test_000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_te
 		"LastAppliedRevision":   "master/b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
 		"LastAttemptedRevision": "master/ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
 		"LastPlannedRevision":   "master/ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
-		"LastAppliedPlan":       "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan":       "plan-master-b8e362c206",
 		"Pending":               "",
 		"Message":               "Plan no changes",
 	}))

--- a/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
+++ b/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
@@ -133,7 +133,7 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	By("checking that we have outputs available in the TF object")

--- a/controllers/tc000220_support_config_file_via_secret_test.go
+++ b/controllers/tc000220_support_config_file_via_secret_test.go
@@ -177,7 +177,7 @@ credentials "app.terraform.io" {
 			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":         "plan-master-b8e362c206",
 		"Is TFPlan empty ?": false,
 	}))
 
@@ -203,7 +203,7 @@ credentials "app.terraform.io" {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	g.Expect(k8sClient.Get(ctx, helloWorldTFKey, &helloWorldTF)).Should(Succeed())
@@ -231,7 +231,7 @@ credentials "app.terraform.io" {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 		"IsDestroy":       true,
 	}))
 

--- a/controllers/tc000241_auto_approve_with_health_checks_test.go
+++ b/controllers/tc000241_auto_approve_with_health_checks_test.go
@@ -150,7 +150,7 @@ func Test_000241_auto_approve_with_health_checks_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	By("checking that we have outputs available in the TF object")

--- a/controllers/tc000280_inventory_test.go
+++ b/controllers/tc000280_inventory_test.go
@@ -177,7 +177,7 @@ func Test_000280_inventory_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -203,7 +203,7 @@ func Test_000280_inventory_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 	// TODO check Output condition
 

--- a/controllers/tc000290_force_unlock_test.go
+++ b/controllers/tc000290_force_unlock_test.go
@@ -176,7 +176,7 @@ func Test_000290_force_unlock_lock_identifier_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -202,7 +202,7 @@ func Test_000290_force_unlock_lock_identifier_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	var tfstateLease coordinationv1.Lease
@@ -414,7 +414,7 @@ func Test_000290_force_unlock_yes_unlock_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -440,7 +440,7 @@ func Test_000290_force_unlock_yes_unlock_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	var tfstateLease coordinationv1.Lease
@@ -690,7 +690,7 @@ func Test_000290_force_unlock_auto_unlock_test(t *testing.T) {
 			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"SavedPlan":             "plan-master-b8e362c206",
 		"Is TFPlan empty ?":     false,
 		"HasEncodingAnnotation": true,
 	}))
@@ -716,7 +716,7 @@ func Test_000290_force_unlock_auto_unlock_test(t *testing.T) {
 		"Type":            infrav1.ConditionTypeApply,
 		"Reason":          infrav1.TFExecApplySucceedReason,
 		"Message":         "Applied successfully",
-		"LastAppliedPlan": "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"LastAppliedPlan": "plan-master-b8e362c206",
 	}))
 
 	var tfstateLease coordinationv1.Lease

--- a/controllers/tc000350_depends_on_test.go
+++ b/controllers/tc000350_depends_on_test.go
@@ -229,7 +229,7 @@ func Test_000350_depends_on_test(t *testing.T) {
 	}, timeout*3, interval).ShouldNot(BeZero())
 
 	Given("the plan id is the `plan` plus the branch name (master) plus the commit id.")
-	const planId = "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb"
+	const planId = "plan-master-b8e362c206"
 
 	By("checking that the planned status of the TF is created successfully.")
 	By("checking the reason is `TerraformPlannedWithChanges`.")

--- a/controllers/tf_controller_plan.go
+++ b/controllers/tf_controller_plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/weaveworks/tf-controller/api/planid"
 
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
 	"github.com/weaveworks/tf-controller/runner"
@@ -137,7 +138,8 @@ func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraf
 
 		// this is the manual mode, we fire the event to show how to apply the plan
 		if forceOrAutoApply == false {
-			_, approveMessage := infrav1.GetPlanIdAndApproveMessage(revision, "Plan generated")
+			planId := planid.GetPlanID(revision)
+			approveMessage := planid.GetApproveMessage(planId, "Plan generated")
 			msg := fmt.Sprintf("Planned.\n%s", approveMessage)
 			r.event(ctx, terraform, revision, eventv1.EventSeverityInfo, msg, nil)
 		}

--- a/runner/server.go
+++ b/runner/server.go
@@ -409,9 +409,11 @@ func (r *TerraformRunnerServer) LoadTFPlan(ctx context.Context, req *LoadTFPlanR
 		return nil, err
 	}
 
-	if tfplanSecret.Annotations[SavedPlanSecretAnnotation] != req.PendingPlan {
+	// this must be the short plan format: see api/planid/plan_id.go
+	pendingPlanId := req.PendingPlan
+	if tfplanSecret.Annotations[SavedPlanSecretAnnotation] != pendingPlanId {
 		err = fmt.Errorf("error pending plan and plan's name in the secret are not matched: %s != %s",
-			req.PendingPlan,
+			pendingPlanId,
 			tfplanSecret.Annotations[SavedPlanSecretAnnotation])
 		log.Error(err, "plan name mismatch")
 		return nil, err


### PR DESCRIPTION
Fixes #599
Fixes #699 

To cope with similar issues in the future, we'll use the short plan id everywhere.
- In the pending plan 
- In the last applied plan
- In the approval message
- Having a dedicated lib for converting a revision to a plan id, in `api/planid/plan_id.go` and having test cases to cover old and new formats.