### PR TITLE
sanitize plan logs

### DIFF
--- a/config/tilt/test/tf-dev-subject.yaml
+++ b/config/tilt/test/tf-dev-subject.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 30s
   url: https://github.com/tf-controller/helloworld
   ref:
-    branch: main
+    branch: dev
 ---
 apiVersion: v1
 kind: Secret
@@ -33,6 +33,9 @@ spec:
     kind: GitRepository
     name: helloworld
     namespace: flux-system
+  vars:
+  - name: secret_subject
+    value: "test-"
   varsFrom:
   - kind: Secret
     name: helloworld-tf

--- a/controllers/tc000290_force_unlock_test.go
+++ b/controllers/tc000290_force_unlock_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func Test_000290_force_unlock_lock_identifier_test(t *testing.T) {
-	Spec("This spec describes the behaviour of a Terraform resource with inventory enabled.")
+	Spec("This spec describes the behaviour of a Terraform resource with force unlock.")
 	It("should be reconciled successfully with a set of inventory entries shown in the status.")
 
 	const (
@@ -628,7 +628,6 @@ func Test_000290_force_unlock_auto_unlock_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
 
 	It("should be created")
 	By("checking that the hello world TF got created")
@@ -767,4 +766,6 @@ func Test_000290_force_unlock_auto_unlock_test(t *testing.T) {
 		"LockIdentifier": "",
 		"ForceUnlock":    infrav1.ForceUnlockEnumAuto,
 	}))
+
+	defer func() { g.Expect(k8sClient.Delete(ctx, &createdHelloWorldTF)).Should(Succeed()) }()
 }

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -450,17 +450,6 @@ func isBeingDeleted(terraform infrav1.Terraform) bool {
 	return !terraform.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
-// Revision is in main/abcdefabcdefabcdefabcdefabcdefabcdefabcdef format
-// We want to return main/abcdefa
-func shortRev(revision string) string {
-	const maxLength = 8
-	if strings.Contains(revision, "/") {
-		return revision[:strings.Index(revision, "/")+maxLength]
-	} else {
-		return revision[:maxLength]
-	}
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *TerraformReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int, httpRetry int) error {
 	// Index the Terraforms by the GitRepository references they (may) point at.

--- a/runner/server_plan.go
+++ b/runner/server_plan.go
@@ -82,7 +82,9 @@ func (r *TerraformRunnerServer) tfPlan(ctx context.Context, opts ...tfexec.PlanO
 	defer r.initLogger(log)
 
 	diff, err := r.tf.Plan(ctx, opts...)
-	if err != nil {
+	// sanitize the error message only if it's not a state lock error
+	var sl *tfexec.ErrStateLocked
+	if err != nil && errors.As(err, &sl) == false {
 		fmt.Fprint(os.Stderr, sanitizeLog(errBuf.String()))
 		err = errors.New(sanitizeLog(err.Error()))
 	}

--- a/runner/server_plan_test.go
+++ b/runner/server_plan_test.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestSanitizeLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no_sanitization_needed",
+			input:    `This is a test log.`,
+			expected: `This is a test log.`,
+		},
+		{
+			name: "sanitization_needed",
+			input: `on generated.auto.tfvars.json line 1:
+			1: {"secret_subject":"test-","subject":"test"}`,
+			expected: `on generated.auto.tfvars.json line 1:
+			1: {"secret_subject":"***","subject":"***"}`,
+		},
+		{
+			name: "sanitization_needed_multiple_lines",
+			input: `This is a test log.
+			on generated.auto.tfvars.json line 1:
+			1: {"secret_subject":"test-","subject":"test"}
+			This is another test log.
+			on generated.auto.tfvars.json line 2:
+			2: {"secret_subject":"test-","subject":"test"}`,
+			expected: `This is a test log.
+			on generated.auto.tfvars.json line 1:
+			1: {"secret_subject":"***","subject":"***"}
+			This is another test log.
+			on generated.auto.tfvars.json line 2:
+			2: {"secret_subject":"***","subject":"***"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeLog(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeLog() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a log sanitization mechanism in the tfPlan function of the tf-runner. The new function, `sanitizeLog`, scans logs for JSON objects in certain lines. It replaces all values in these JSON objects with asterisks to hide potentially sensitive data.

Then `tfPlan` has been modified to use `sanitizeLog` function. It discards standard output and captures standard error into a buffer for sanitization. If an error occurs, `sanitizeLog` is used to sanitize both the stderr output and the error message.