### PR TITLE
import client-go auth plugin for oidc

### DIFF
--- a/tfctl/main.go
+++ b/tfctl/main.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
Fixes #357 

This PR unblocks users and enables them to utilize the break-the-glass feature properly.

It resolves an issue where our program failed to find an OpenID Connect (OIDC) authentication provider, resulting in an error "no Auth Provider found for name 'oidc'".

To address this, I have added a blank import for the `k8s.io/client-go/plugin/pkg/client/auth` package in tfctl `main.go` file. This import ensures that the necessary authentication plugins, including the OIDC plugin, are registered during the program's initialization.

This is how the fix works:

- The Go runtime imports all packages specified in the tfctl `main.go` file, including `k8s.io/client-go/plugin/pkg/client/auth`.
- During the import process, it is executed if an `init()` function exists in the auth package.
- The `init()` function in the auth package, in turn, registers all of the authentication providers it houses, including the OIDC provider.
- Subsequently, when our program tries to leverage OIDC for authentication, the corresponding provider is successfully found since it was registered during the import process.

As a result, the program no longer throws the "no Auth Provider found for name 'oidc'" error and runs as expected.

This change doesn't affect any existing functionalities but ensures our program has the necessary support for OIDC authentication.