### PR TITLE
chore(ci): do not run test and e2e test when there are no code changes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,13 @@ name: e2e
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "hack/**"
+      - "logos/**"
+      - "rfcs/**"
+      - "tools/**"
+      - "*.md"
   push:
     branches:
       - main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,14 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "charts/**"
+      - "docs/**"
+      - "hack/**"
+      - "logos/**"
+      - "rfcs/**"
+      - "tools/**"
+      - "*.md"
   push:
     branches:
       - main


### PR DESCRIPTION
The test and e2e test workflows can run for 20-30 minutes and they use a lot of resources. If a commit/pull request contains only docs changes, it's a waste of time and resources.

`charts/**` can be ignored for tests, but not for e2e tests because that workflow uses helm charts.

Closes #688

References:
* https://github.com/weaveworks/tf-controller/issues/688