### PR TITLE
fix tfctl message when we're in the plan only mode

### DIFF
--- a/config/tilt/test/tf-dev-subject.yaml
+++ b/config/tilt/test/tf-dev-subject.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 30s
   url: https://github.com/tf-controller/helloworld
   ref:
-    branch: dev
+    branch: main
 ---
 apiVersion: v1
 kind: Secret

--- a/mtls/rotator.go
+++ b/mtls/rotator.go
@@ -208,6 +208,7 @@ tickerLoop:
 			if err := cr.refreshCACertsIfNeeded(); err != nil {
 				crLog.Error(err, "could not refresh cert")
 			}
+
 			// if no channel passing it, skip
 			if trigger.Ready != nil {
 				n := len(cr.artifactCaches)
@@ -649,6 +650,7 @@ func (cr *CertRotator) generateNamespaceTLS(namespace string) (*corev1.Secret, e
 	}
 
 	name := fmt.Sprintf("%s-%d", infrav1.RunnerTLSSecretName, caArtifacts.validUntil.Unix())
+	trueVar := true
 	tlsCertSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -657,7 +659,8 @@ func (cr *CertRotator) generateNamespaceTLS(namespace string) (*corev1.Secret, e
 				infrav1.RunnerLabel: "true",
 			},
 		},
-		Type: corev1.SecretTypeTLS,
+		Immutable: &trueVar, // we set immutable to true to reduce loads on the ETCd server
+		Type:      corev1.SecretTypeTLS,
 		Data: map[string][]byte{
 			caCertName: caArtifacts.CertPEM,
 			caKeyName:  caArtifacts.KeyPEM,

--- a/mtls/rotator.go
+++ b/mtls/rotator.go
@@ -650,7 +650,7 @@ func (cr *CertRotator) generateNamespaceTLS(namespace string) (*corev1.Secret, e
 	}
 
 	name := fmt.Sprintf("%s-%d", infrav1.RunnerTLSSecretName, caArtifacts.validUntil.Unix())
-	trueVar := true
+	isImmutable := true
 	tlsCertSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -659,7 +659,7 @@ func (cr *CertRotator) generateNamespaceTLS(namespace string) (*corev1.Secret, e
 				infrav1.RunnerLabel: "true",
 			},
 		},
-		Immutable: &trueVar, // we set immutable to true to reduce loads on the ETCd server
+		Immutable: &isImmutable, // we set immutable to true to reduce loads on the ETCd server
 		Type:      corev1.SecretTypeTLS,
 		Data: map[string][]byte{
 			caCertName: caArtifacts.CertPEM,

--- a/tfctl/replan.go
+++ b/tfctl/replan.go
@@ -36,7 +36,8 @@ func (c *CLI) Replan(out io.Writer, resource string) error {
 	}
 	fmt.Fprintf(out, " Replan requested for %s/%s\n", c.namespace, resource)
 
-	if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+	// wait for the plan to be ready, 4 loops, 30 seconds each
+	if err := wait.Poll(1*time.Second, 120*time.Second, func() (bool, error) {
 		terraform := &infrav1.Terraform{}
 		if err := c.client.Get(context.TODO(), key, terraform); err != nil {
 			return false, err

--- a/tfctl/show_plan.go
+++ b/tfctl/show_plan.go
@@ -69,7 +69,11 @@ func (c *CLI) ShowPlan(out io.Writer, resource string) error {
 		cond := apimeta.FindStatusCondition(terraform.Status.Conditions, meta.ReadyCondition)
 		if cond != nil {
 			fmt.Fprintln(out, cond.Message)
-			fmt.Fprintf(out, "To set the field, you can also run:\n\n  tfctl approve %s -f filename.yaml \n", resource)
+			if cond.Message == "Plan generated: This object is in the plan only mode." {
+				// do nothing
+			} else {
+				fmt.Fprintf(out, "To set the field, you can also run:\n\n  tfctl approve %s -f filename.yaml \n", resource)
+			}
 		}
 
 	} else if terraform.Spec.StoreReadablePlan == "json" {


### PR DESCRIPTION
Fixes #737 
Fixes #709 
Fixes #657

There are two cases

1. Replan request timed out. This error was caused by a race condition during the controller restart & the recreation of new runners.
2. `tfctl replan` is working fine. This PR fixes only the display message.

** Fix for case no 1**
Simply by checking the Secret, if not found re-create it.

**Fix for case no 2** 
Previous message:
```
❯ tfctl get
NAMESPACE       NAME            READY   MESSAGE                                                 PLAN PENDING    AGE       
flux-system     helloworld-tf   Unknown Plan generated: This object is in the plan only mode.   true            2 minutes

❯ tfctl replan helloworld-tf
 Replan requested for flux-system/helloworld-tf

Changes to Outputs:
  + hello_world = "Hello Plan plan, test!"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Plan generated: This object is in the plan only mode.
To set the field, you can also run:

  tfctl approve helloworld-tf -f filename.yaml 
```

After fixing by this PR:
```
❯ ./bin/tfctl show plan helloworld-tf

Changes to Outputs:
  + hello_world = "Hello Plan plan, test!"

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.

Plan generated: This object is in the plan only mode.

```