### PR TITLE
refactor: add build sha and version to go run tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,15 @@ install-cli:
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run cmd/manager/main.go
+	go run \
+		-ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" \
+		./cmd/manager/main.go
+
+.PHONY: run-planner
+run-planner: manifests generate fmt vet ## Run a branch planner from your host.
+	go run \
+		-ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" \
+		./cmd/branch-planner/
 
 .PHONY: docker-build
 docker-build: ## Build docker


### PR DESCRIPTION
With `go run`, it's still beneficial to get BuildSHA. With this information when we share logs with others we can verify it's on the latest commit on main, or we can simply checkout that specific commit to see if we can reproduce an issue. We can ask for this, but if it's already in the copied logs, we don't have to ask.

## Example

Command:

```
make run-planner
```

Output:

```json
{"level":"info","ts":"2023-07-11T15:32:28.249+0200","logger":"informer","msg":"Starting branch-based planner informer","version":"v0.15.1","sha":"5a2d800"}
{"level":"info","ts":"2023-07-11T15:32:28.249+0200","logger":"polling-server","msg":"Starting polling server","version":"v0.15.1","sha":"5a2d800"}
{"level":"error","ts":"2023-07-11T15:32:28.256+0200","logger":"informer","msg":"branch-based planner informer failed","version":"v0.15.1","sha":"5a2d800","error":"failed to create git provider: failed to read config: unable to get ConfigMap: configmaps \"branch-planner\" not found"}
```