### PR TITLE
patch: use "flux-system" namespace instead of "default" for config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ import (
 //   secretName: bbp-token
 //   # List of Terraform resources
 //   resources: |-
-//     - namespace: default
+//     - namespace: flux-system
 //       name: tf1
 //     - namespace: default
 //       name: tf2
@@ -57,7 +57,7 @@ func ReadConfig(ctx context.Context, clusterClient client.Client, ref types.Name
 	resourceData := configMap.Data["resources"]
 
 	if config.SecretNamespace == "" {
-		config.SecretNamespace = "default"
+		config.SecretNamespace = "flux-system"
 	}
 
 	err = yaml.Unmarshal([]byte(resourceData), &config.Resources)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ func ReadConfig(ctx context.Context, clusterClient client.Client, ref types.Name
 
 func ObjectKeyFromName(configMapName string) (client.ObjectKey, error) {
 	key := client.ObjectKey{}
-	namespace := "default"
+	namespace := "flux-system"
 	name := ""
 	parts := strings.SplitN(configMapName, "/", 2)
 

--- a/internal/server/polling/config.go
+++ b/internal/server/polling/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/weaveworks/tf-controller/internal/config"
 )
 
-const DefaultConfigMapName = "default/branch-planner"
+const DefaultConfigMapName = "flux-system/branch-planner"
 
 func (s *Server) readConfig(ctx context.Context) (*config.Config, error) {
 	configMap, err := config.ReadConfig(ctx, s.clusterClient, s.configMapRef)


### PR DESCRIPTION
The branch planner program would run inside `flux-system` by default, so configuration is assumed to be read from the `flux-system` instead of `default`.

Closes #760

References:
* https://github.com/weaveworks/tf-controller/issues/760