### PR TITLE
feat: support watching all Terraform objects in namespace

### DIFF
--- a/cmd/branch-planner/informer.go
+++ b/cmd/branch-planner/informer.go
@@ -70,7 +70,7 @@ func createProvider(ctx context.Context, clusterClient client.Client, configMapN
 	return gitProvider, nil
 }
 
-func createSharedInformer(ctx context.Context, client client.Client, dynamicClient dynamic.Interface) (cache.SharedIndexInformer, error) {
+func createSharedInformer(_ context.Context, client client.Client, dynamicClient dynamic.Interface) (cache.SharedIndexInformer, error) {
 	restMapper := client.RESTMapper()
 	mapping, err := restMapper.RESTMapping(tfv1alpha2.GroupVersion.WithKind(tfv1alpha2.TerraformKind).GroupKind())
 	if err != nil {
@@ -78,7 +78,7 @@ func createSharedInformer(ctx context.Context, client client.Client, dynamicClie
 	}
 
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = fmt.Sprintf("%s=%s", planner.LabelKey, planner.LabelValue)
+		options.LabelSelector = fmt.Sprintf("%s=%s", config.LabelKey, config.LabelValue)
 	}
 
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Minute, corev1.NamespaceAll, tweakListOptionsFunc)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	LabelKey            = "infra.weave.works/branch-planner"
+	LabelValue          = "true"
+	LabelPRIDKey string = "infra.weave.works/pr-id"
+)
+
 // Example ConfigMap
 //
 // The secret is a reference to a secret with a 'token' key.

--- a/internal/informer/branch-planner/informer_test.go
+++ b/internal/informer/branch-planner/informer_test.go
@@ -12,6 +12,7 @@ import (
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/internal/config"
 	"github.com/weaveworks/tf-controller/internal/git/provider/providerfakes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +48,7 @@ func TestInformer(t *testing.T) {
 			Name:      "helloworld",
 			Namespace: ns.Name,
 			Labels: map[string]string{
-				LabelKey:                  LabelValue,
+				config.LabelKey:           config.LabelValue,
 				"infra.weave.works/pr-id": "1",
 			},
 		},
@@ -123,7 +124,7 @@ func createSharedInformer(g *WithT, ctx context.Context, client client.Client, d
 	g.Expect(err).NotTo(HaveOccurred())
 
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = fmt.Sprintf("%s=%s", LabelKey, LabelValue)
+		options.LabelSelector = fmt.Sprintf("%s=%s", config.LabelKey, config.LabelValue)
 	}
 
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Minute, corev1.NamespaceAll, tweakListOptionsFunc)

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -7,7 +7,7 @@ import (
 
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
-	planner "github.com/weaveworks/tf-controller/internal/informer/branch-planner"
+	bpconfig "github.com/weaveworks/tf-controller/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
@@ -24,14 +24,14 @@ func (s *Server) getTerraformObject(ctx context.Context, ref client.ObjectKey) (
 	return obj, nil
 }
 
-func (s *Server) listTerraformObjects(ctx context.Context, tf *infrav1.Terraform, labels map[string]string) ([]*infrav1.Terraform, error) {
+func (s *Server) listTerraformObjects(ctx context.Context, namespace string, labels map[string]string) ([]*infrav1.Terraform, error) {
 	tfList := &infrav1.TerraformList{}
 
 	if err := s.clusterClient.List(ctx, tfList,
 		client.MatchingLabelsSelector{
 			Selector: k8sLabels.Set(labels).AsSelector(),
 		},
-		client.InNamespace(tf.Namespace),
+		client.InNamespace(namespace),
 	); err != nil {
 		return nil, fmt.Errorf("unable to list Terraform objects: %w", err)
 	}
@@ -148,8 +148,8 @@ func (s *Server) createLabels(labels map[string]string, branch string, prID stri
 		labels = make(map[string]string)
 	}
 
-	labels[planner.LabelKey] = planner.LabelValue
-	labels[planner.LabelPRIDKey] = prID
+	labels[bpconfig.LabelKey] = bpconfig.LabelValue
+	labels[bpconfig.LabelPRIDKey] = prID
 
 	return labels
 }


### PR DESCRIPTION
Currently we have exact definition for resources. To make it easier to use if `name` is not defined in the ConfigMap for a resource, polling will be used on all Terraform objects in the defined namespace.

Example config:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: branch-based-planner
data:
  secretMamespace: flux-system
  secretName: bbp-token
  resources: |-
    - namespace: flux-system
```

Logging:

```json
{"level":"info","ts":"2023-07-11T17:59:42.065+0200","logger":"informer","msg":"Starting branch-based planner informer","version":"v0.15.1","sha":"87527a4d9e8643167909e71b855a22062ba9c41b"}
{"level":"info","ts":"2023-07-11T17:59:42.066+0200","logger":"polling-server","msg":"Starting polling server","version":"v0.15.1","sha":"87527a4d9e8643167909e71b855a22062ba9c41b"}
{"level":"info","ts":"2023-07-11T18:00:12.097+0200","logger":"polling-server","msg":"checking all Terrafrom objects in namespace","version":"v0.15.1","sha":"87527a4d9e8643167909e71b855a22062ba9c41b","namespace":"flux-system"}
{"level":"info","ts":"2023-07-11T18:00:12.104+0200","logger":"polling-server","msg":"start polling","version":"v0.15.1","sha":"87527a4d9e8643167909e71b855a22062ba9c41b","namespace":"flux-system","name":"helloworld-tf"}
{"level":"info","ts":"2023-07-11T18:00:12.107+0200","logger":"KubeAPIWarningLogger","msg":"v1beta2 GitRepository is deprecated, upgrade to v1","version":"v0.15.1","sha":"87527a4d9e8643167909e71b855a22062ba9c41b"}
```

Closes #764

References:
* https://github.com/weaveworks/tf-controller/issues/764