### PR TITLE
Improving ConfigMap Handling and Parsing Object Key, Removed Redundant Notation for the Controller and the Branch Planner

### DIFF
--- a/api/v1alpha2/terraform_types.go
+++ b/api/v1alpha2/terraform_types.go
@@ -552,7 +552,7 @@ func TerraformApplying(terraform Terraform, revision string, message string) Ter
 	}
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
 	if revision != "" {
-		(&terraform).Status.LastAttemptedRevision = revision
+		terraform.Status.LastAttemptedRevision = revision
 	}
 	return terraform
 }
@@ -565,7 +565,7 @@ func TerraformOutputsAvailable(terraform Terraform, availableOutputs []string, m
 		Message: trimString(message, MaxConditionMessageLength),
 	}
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
-	(&terraform).Status.AvailableOutputs = availableOutputs
+	terraform.Status.AvailableOutputs = availableOutputs
 	return terraform
 }
 
@@ -592,20 +592,20 @@ func TerraformApplied(terraform Terraform, revision string, message string, isDe
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
 
 	if terraform.Status.Plan.IsDriftDetectionPlan {
-		(&terraform).Status.LastAppliedByDriftDetectionAt = &metav1.Time{Time: time.Now()}
+		terraform.Status.LastAppliedByDriftDetectionAt = &metav1.Time{Time: time.Now()}
 	}
 
-	(&terraform).Status.Plan = PlanStatus{
+	terraform.Status.Plan = PlanStatus{
 		LastApplied:   terraform.Status.Plan.Pending,
 		Pending:       "",
 		IsDestroyPlan: isDestroyApply,
 	}
 	if revision != "" {
-		(&terraform).Status.LastAppliedRevision = revision
+		terraform.Status.LastAppliedRevision = revision
 	}
 
 	if len(entries) > 0 {
-		(&terraform).Status.Inventory = &ResourceInventory{Entries: entries}
+		terraform.Status.Inventory = &ResourceInventory{Entries: entries}
 	}
 
 	SetTerraformReadiness(&terraform, metav1.ConditionUnknown, TFExecApplySucceedReason, message+": "+revision, revision)
@@ -620,14 +620,14 @@ func TerraformPostPlanningWebhookFailed(terraform Terraform, revision string, me
 		Message: trimString(message, MaxConditionMessageLength),
 	}
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
-	(&terraform).Status.Plan = PlanStatus{
+	terraform.Status.Plan = PlanStatus{
 		LastApplied:   terraform.Status.Plan.LastApplied,
 		Pending:       "",
 		IsDestroyPlan: terraform.Spec.Destroy,
 	}
 	if revision != "" {
-		(&terraform).Status.LastAttemptedRevision = revision
-		(&terraform).Status.LastPlannedRevision = revision
+		terraform.Status.LastAttemptedRevision = revision
+		terraform.Status.LastPlannedRevision = revision
 	}
 
 	return terraform
@@ -644,18 +644,18 @@ func TerraformPlannedWithChanges(terraform Terraform, revision string, forceOrAu
 		Message: trimString(message, MaxConditionMessageLength),
 	}
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
-	(&terraform).Status.Plan = PlanStatus{
+	terraform.Status.Plan = PlanStatus{
 		LastApplied:          terraform.Status.Plan.LastApplied,
 		Pending:              planId, // pending plan id is always the short plan format.
 		IsDestroyPlan:        terraform.Spec.Destroy,
 		IsDriftDetectionPlan: terraform.HasDrift(),
 	}
 	if revision != "" {
-		(&terraform).Status.LastAttemptedRevision = revision
-		(&terraform).Status.LastPlannedRevision = revision
+		terraform.Status.LastAttemptedRevision = revision
+		terraform.Status.LastPlannedRevision = revision
 	}
 
-	(&terraform).Status.LastPlanAt = &metav1.Time{Time: time.Now()}
+	terraform.Status.LastPlanAt = &metav1.Time{Time: time.Now()}
 
 	// planOnly takes the highest precedence
 	if terraform.Spec.PlanOnly {
@@ -677,17 +677,17 @@ func TerraformPlannedNoChanges(terraform Terraform, revision string, message str
 		Message: trimString(message, MaxConditionMessageLength),
 	}
 	apimeta.SetStatusCondition(terraform.GetStatusConditions(), newCondition)
-	(&terraform).Status.Plan = PlanStatus{
+	terraform.Status.Plan = PlanStatus{
 		LastApplied:   terraform.Status.Plan.LastApplied,
 		Pending:       "",
 		IsDestroyPlan: terraform.Spec.Destroy,
 	}
 	if revision != "" {
-		(&terraform).Status.LastAttemptedRevision = revision
-		(&terraform).Status.LastPlannedRevision = revision
+		terraform.Status.LastAttemptedRevision = revision
+		terraform.Status.LastPlannedRevision = revision
 	}
 
-	(&terraform).Status.LastPlanAt = &metav1.Time{Time: time.Now()}
+	terraform.Status.LastPlanAt = &metav1.Time{Time: time.Now()}
 
 	SetTerraformReadiness(&terraform, metav1.ConditionTrue, PlannedNoChangesReason, message+": "+revision, revision)
 	return terraform
@@ -729,7 +729,7 @@ func TerraformAppliedFailResetPlanAndNotReady(terraform Terraform, revision, rea
 }
 
 func TerraformDriftDetected(terraform Terraform, revision, reason, message string) Terraform {
-	(&terraform).Status.LastDriftDetectedAt = &metav1.Time{Time: time.Now()}
+	terraform.Status.LastDriftDetectedAt = &metav1.Time{Time: time.Now()}
 
 	SetTerraformReadiness(&terraform, metav1.ConditionFalse, reason, trimString(message, MaxConditionMessageLength), revision)
 	return terraform

--- a/cmd/branch-planner/informer.go
+++ b/cmd/branch-planner/informer.go
@@ -62,6 +62,9 @@ func createProvider(ctx context.Context, clusterClient client.Client, configMapN
 		return nil, fmt.Errorf("unable to get bbp config secret: %w", err)
 	}
 
+	if bbpProviderSecret.Data == nil || bbpProviderSecret.Data["token"] == nil {
+		return nil, fmt.Errorf("provider secret has no token")
+	}
 	gitProvider, err := provider.New(provider.ProviderGitHub, provider.WithToken("api-token", string(bbpProviderSecret.Data["token"])))
 	if err != nil {
 		return nil, fmt.Errorf("unable to get provider: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,17 +72,16 @@ func ObjectKeyFromName(configMapName string) (client.ObjectKey, error) {
 	key := client.ObjectKey{}
 	namespace := "default"
 	name := ""
-	parts := strings.SplitN(configMapName, "/", 2)
+	parts := strings.Split(configMapName, "/")
 
-	if len(parts) < 1 {
-		return key, fmt.Errorf("invalid ConfigMap reference: %q", configMapName)
-	}
-
-	if len(parts) < 2 {
+	switch len(parts) {
+	case 1:
 		name = parts[0]
-	} else {
+	case 2:
 		namespace = parts[0]
 		name = parts[1]
+	default:
+		return key, fmt.Errorf("invalid ConfigMap reference: %q", configMapName)
 	}
 
 	if name == "" || namespace == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"testing"
+)
+
+func Test_ObjectKeyFromName_invalid(t *testing.T) {
+	for _, s := range []string{
+		"foo/bar/baz",
+		"/bar",
+		"foo/",
+		"",
+	} {
+		t.Run(s, func(t *testing.T) {
+			_, err := ObjectKeyFromName(s)
+			if err == nil {
+				t.Fatal("expected error due to invalid object name, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
These are just some things I noticed looking at PRs.

 - configmap.Data is a map and can be nil, so check for that to avoid an NPE, and check the expected field is there so it can fail there and then rather than more mysteriously and later
 - be more precise when parsing an object key from a string
 - remove a bunch of unnecessary notation that made me have to pause and figure out why it was there. I still don't know, but it's not necessary, so to save the next person trying to figure it out, ...
