### PR TITLE
if force mode is true, we skip the plan annotation check

### DIFF
--- a/runner/server.go
+++ b/runner/server.go
@@ -390,59 +390,6 @@ func (r *TerraformRunnerServer) SelectWorkspace(ctx context.Context, req *Worksp
 	return &WorkspaceReply{Message: "ok"}, nil
 }
 
-func (r *TerraformRunnerServer) LoadTFPlan(ctx context.Context, req *LoadTFPlanRequest) (*LoadTFPlanReply, error) {
-	log := ctrl.LoggerFrom(ctx, "instance-id", r.InstanceID).WithName(loggerName)
-	log.Info("loading plan from secret")
-	if req.TfInstance != r.InstanceID {
-		err := fmt.Errorf("no TF instance found")
-		log.Error(err, "no terraform")
-		return nil, err
-	}
-
-	tfplanSecretKey := types.NamespacedName{Namespace: req.Namespace, Name: "tfplan-" + r.terraform.WorkspaceName() + "-" + req.Name}
-	tfplanSecret := corev1.Secret{}
-	err := r.Get(ctx, tfplanSecretKey, &tfplanSecret)
-	if err != nil {
-		err = fmt.Errorf("error getting plan secret: %s", err)
-		log.Error(err, "unable to get secret")
-		return nil, err
-	}
-
-	if r.terraform.Spec.Force == true {
-		// skip the annotation check
-		log.Info("force mode, skipping the plan's annotation check")
-	} else {
-		// this must be the short plan format: see api/planid/plan_id.go
-		pendingPlanId := req.PendingPlan
-		if tfplanSecret.Annotations[SavedPlanSecretAnnotation] != pendingPlanId {
-			err = fmt.Errorf("error pending plan and plan's name in the secret are not matched: %s != %s",
-				pendingPlanId,
-				tfplanSecret.Annotations[SavedPlanSecretAnnotation])
-			log.Error(err, "plan name mismatch")
-			return nil, err
-		}
-	}
-
-	if req.BackendCompletelyDisable {
-		// do nothing
-	} else {
-		tfplan := tfplanSecret.Data[TFPlanName]
-		tfplan, err = utils.GzipDecode(tfplan)
-		if err != nil {
-			log.Error(err, "unable to decode the plan")
-			return nil, err
-		}
-		err = os.WriteFile(filepath.Join(r.tf.WorkingDir(), TFPlanName), tfplan, 0644)
-		if err != nil {
-			err = fmt.Errorf("error saving plan file to disk: %s", err)
-			log.Error(err, "unable to write the plan to disk")
-			return nil, err
-		}
-	}
-
-	return &LoadTFPlanReply{Message: "ok"}, nil
-}
-
 func (r *TerraformRunnerServer) Destroy(ctx context.Context, req *DestroyRequest) (*DestroyReply, error) {
 	log := ctrl.LoggerFrom(ctx, "instance-id", r.InstanceID).WithName(loggerName)
 	log.Info("running destroy")

--- a/runner/server_load_tfplan.go
+++ b/runner/server_load_tfplan.go
@@ -48,7 +48,7 @@ func loadTFPlan(
 		return nil, err
 	}
 
-	if terraform.Spec.Force == true {
+	if terraform.Spec.Force {
 		// skip the annotation check
 		log.Info("force mode, skipping the plan's annotation check")
 	} else {

--- a/runner/server_load_tfplan.go
+++ b/runner/server_load_tfplan.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/spf13/afero"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *TerraformRunnerServer) LoadTFPlan(ctx context.Context, req *LoadTFPlanRequest) (*LoadTFPlanReply, error) {
+	log := ctrl.LoggerFrom(ctx, "instance-id", r.InstanceID).WithName(loggerName)
+	log.Info("loading plan from secret")
+
+	if req.TfInstance != r.InstanceID {
+		err := fmt.Errorf("no TF instance found")
+		log.Error(err, "no terraform")
+		return nil, err
+	}
+
+	fs := afero.NewOsFs()
+	return loadTFPlan(ctx, log, req, r.terraform, r.tf.WorkingDir(), r.Client, fs)
+}
+
+// loadTFPlan loads the plan from the secret and returns the plan as a reply.
+func loadTFPlan(
+	ctx context.Context,
+	log logr.Logger,
+	req *LoadTFPlanRequest,
+	terraform *infrav1.Terraform,
+	workingDir string,
+	client client.Client,
+	fs afero.Fs,
+) (*LoadTFPlanReply, error) {
+	tfplanSecretKey := types.NamespacedName{Namespace: req.Namespace, Name: "tfplan-" + terraform.WorkspaceName() + "-" + req.Name}
+	tfplanSecret := corev1.Secret{}
+	err := client.Get(ctx, tfplanSecretKey, &tfplanSecret)
+	if err != nil {
+		err = fmt.Errorf("error getting plan secret: %s", err)
+		log.Error(err, "unable to get secret")
+		return nil, err
+	}
+
+	if terraform.Spec.Force == true {
+		// skip the annotation check
+		log.Info("force mode, skipping the plan's annotation check")
+	} else {
+		// this must be the short plan format: see api/planid/plan_id.go
+		pendingPlanId := req.PendingPlan
+		if tfplanSecret.Annotations[SavedPlanSecretAnnotation] != pendingPlanId {
+			err = fmt.Errorf("error pending plan and plan's name in the secret are not matched: %s != %s",
+				pendingPlanId,
+				tfplanSecret.Annotations[SavedPlanSecretAnnotation])
+			log.Error(err, "plan name mismatch")
+			return nil, err
+		}
+	}
+
+	if req.BackendCompletelyDisable {
+		// do nothing
+	} else {
+		tfplan := tfplanSecret.Data[TFPlanName]
+		tfplan, err = utils.GzipDecode(tfplan)
+		if err != nil {
+			log.Error(err, "unable to decode the plan")
+			return nil, err
+		}
+		err = afero.WriteFile(fs, filepath.Join(workingDir, TFPlanName), tfplan, 0644)
+		if err != nil {
+			err = fmt.Errorf("error saving plan file to disk: %s", err)
+			log.Error(err, "unable to write the plan to disk")
+			return nil, err
+		}
+	}
+
+	return &LoadTFPlanReply{Message: "ok"}, nil
+}

--- a/runner/server_load_tfplan_test.go
+++ b/runner/server_load_tfplan_test.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLoadTFPlanWithForceTrue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.TODO()
+	log := logr.Discard()
+	fs := afero.NewMemMapFs()
+
+	req := &LoadTFPlanRequest{
+		Name:                     "test",
+		Namespace:                "default",
+		PendingPlan:              "plan-is-1",
+		BackendCompletelyDisable: false,
+	}
+
+	terraform := &infrav1.Terraform{
+		Spec: infrav1.TerraformSpec{
+			Force: true,
+		},
+	}
+
+	const workingDir = "/tmp"
+
+	data, err := utils.GzipEncode([]byte("plan data")) // Assuming GzipEncode returns a byte slice
+	g.Expect(err).NotTo(HaveOccurred(), "should not return an error")
+
+	secretData := map[string][]byte{
+		TFPlanName: data,
+	}
+
+	tfplanSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "tfplan-" + terraform.WorkspaceName() + "-" + req.Name,
+			Namespace:   req.Namespace,
+			Annotations: map[string]string{SavedPlanSecretAnnotation: "plan-not-1"},
+		},
+		Data: secretData,
+	}
+
+	// Mock the Kubernetes client.
+	client := fake.NewClientBuilder().WithObjects(tfplanSecret).Build()
+
+	// Act: Call the function under test.
+	reply, loadPlanErr := loadTFPlan(ctx, log, req, terraform, workingDir, client, fs)
+
+	// Assert: Check that the function behaved as expected.
+	g.Expect(loadPlanErr).NotTo(HaveOccurred(), "should not return an error")
+	g.Expect(reply).To(Equal(&LoadTFPlanReply{Message: "ok"}), "should return the expected reply")
+
+	// Assert: Check that the expected file was written to the mock filesystem.
+	expectedData, _ := utils.GzipDecode(secretData[TFPlanName])
+	actualData, _ := afero.ReadFile(fs, filepath.Join(workingDir, TFPlanName))
+	g.Expect(actualData).To(Equal(expectedData), "should write the expected data to the filesystem")
+}
+
+func TestLoadTFPlanWithForceFalse(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := context.TODO()
+	log := logr.Discard()
+	fs := afero.NewMemMapFs()
+
+	req := &LoadTFPlanRequest{
+		Name:                     "test",
+		Namespace:                "default",
+		PendingPlan:              "plan-is-1",
+		BackendCompletelyDisable: false,
+	}
+
+	terraform := &infrav1.Terraform{
+		Spec: infrav1.TerraformSpec{
+			Force: false,
+		},
+	}
+
+	const workingDir = "/tmp"
+
+	data, err := utils.GzipEncode([]byte("plan data")) // Assuming GzipEncode returns a byte slice
+	g.Expect(err).NotTo(HaveOccurred(), "should not return an error")
+
+	secretData := map[string][]byte{
+		TFPlanName: data,
+	}
+
+	tfplanSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "tfplan-" + terraform.WorkspaceName() + "-" + req.Name,
+			Namespace:   req.Namespace,
+			Annotations: map[string]string{SavedPlanSecretAnnotation: "plan-not-1"},
+		},
+		Data: secretData,
+	}
+
+	// Mock the Kubernetes client.
+	client := fake.NewClientBuilder().WithObjects(tfplanSecret).Build()
+
+	// Act: Call the function under test.
+	reply, loadPlanErr := loadTFPlan(ctx, log, req, terraform, workingDir, client, fs)
+
+	// Assert: loadPlanErr should contain an error
+	g.Expect(loadPlanErr).To(HaveOccurred(), "should return an error")
+
+	// Assert: reply should be nil
+	g.Expect(reply).To(BeNil(), "should return nil reply")
+}


### PR DESCRIPTION
Fixes #745

In response to user feedback, we are implementing a fix where the plan annotation check is bypassed if in force mode. This update is intended to mitigate the prevalent issue experienced by many users who were struggling with the Terraform controller bug. This bug was caused by a failure in parsing of the Flux revision format change from v0.41 to v2, and many users thought that changing `force: true` would forcefully apply the plan regardless and no error.