### PR TITLE
feat: use RUNTIME_NAMESPACE for resources if namespace is not defined

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controll
 
 RUN apk update
 
-RUN apk add --no-cache libcrypto3=3.1.1-r1 && \
-    apk add --no-cache libssl3=3.1.1-r1 && \
+RUN apk add --no-cache libcrypto3=3.1.1-r2 && \
+    apk add --no-cache libssl3=3.1.1-r2 && \
     apk add --no-cache ca-certificates tini git openssh-client gnupg && \
     apk add --no-cache libretls && \
     apk add --no-cache busybox

--- a/cmd/branch-planner/flags.go
+++ b/cmd/branch-planner/flags.go
@@ -26,7 +26,7 @@ func parseFlags() *applicationOptions {
 
 	flag.StringVar(&opts.pollingConfigMap,
 		"polling-configmap", polling.DefaultConfigMapName,
-		"Namespace and name of the ConfigMap for the polling service.")
+		"\"Namespace/Name\" of the ConfigMap for the polling service. If Namespace is omitted, runtime namespace will be used.")
 
 	flag.DurationVar(&opts.pollingInterval,
 		"polling-interval", polling.DefaultPollingInterval,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,18 @@
-package config
+package config_test
 
 import (
+	"context"
+	"os"
 	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/weaveworks/tf-controller/internal/config"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_ObjectKeyFromName_invalid(t *testing.T) {
@@ -12,10 +23,83 @@ func Test_ObjectKeyFromName_invalid(t *testing.T) {
 		"",
 	} {
 		t.Run(s, func(t *testing.T) {
-			_, err := ObjectKeyFromName(s)
+			_, err := config.ObjectKeyFromName(s)
 			if err == nil {
 				t.Fatal("expected error due to invalid object name, got nil")
 			}
 		})
 	}
+}
+
+func Test_ReadConfig_empty(t *testing.T) {
+	g := gomega.NewWithT(t)
+	targetNS := "separate-ns"
+
+	os.Setenv("RUNTIME_NAMESPACE", targetNS)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-planner-config",
+			Namespace: "separate-ns",
+		},
+		Data: map[string]string{},
+	}
+	objects := []client.Object{configMap}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+
+	conf, err := config.ReadConfig(context.Background(), fakeClient, types.NamespacedName{
+		Name: "branch-planner-config",
+	})
+	g.Expect(err).To(gomega.Succeed())
+
+	g.Expect(conf.SecretName).To(gomega.Equal(""))
+	g.Expect(conf.SecretNamespace).To(gomega.Equal(targetNS))
+	g.Expect(conf.Resources).To(gomega.HaveLen(0))
+}
+
+func Test_ReadConfig_resources(t *testing.T) {
+	g := gomega.NewWithT(t)
+	targetNS := "separate-ns"
+
+	os.Setenv("RUNTIME_NAMESPACE", targetNS)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-planner-config",
+			Namespace: "separate-ns",
+		},
+		Data: map[string]string{
+			"resources": func() string {
+				resources := []client.ObjectKey{
+					{Name: "mytf-1", Namespace: "myns"},
+					{Name: "mytf-2"},
+					{Namespace: "myns"},
+				}
+
+				data, _ := yaml.Marshal(resources)
+
+				return string(data)
+			}(),
+		},
+	}
+
+	objects := []client.Object{configMap}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+
+	conf, err := config.ReadConfig(context.Background(), fakeClient, types.NamespacedName{
+		Name: "branch-planner-config",
+	})
+	g.Expect(err).To(gomega.Succeed())
+
+	g.Expect(conf.SecretName).To(gomega.Equal(""))
+	g.Expect(conf.SecretNamespace).To(gomega.Equal(targetNS))
+	g.Expect(conf.Resources).To(gomega.HaveLen(3))
+	g.Expect(conf.Resources[0].Name).To(gomega.Equal("mytf-1"))
+	g.Expect(conf.Resources[0].Namespace).To(gomega.Equal("myns"))
+	g.Expect(conf.Resources[1].Name).To(gomega.Equal("mytf-2"))
+	g.Expect(conf.Resources[1].Namespace).To(gomega.Equal(targetNS))
+	g.Expect(conf.Resources[2].Name).To(gomega.Equal(""))
+	g.Expect(conf.Resources[2].Namespace).To(gomega.Equal("myns"))
 }

--- a/internal/server/polling/config.go
+++ b/internal/server/polling/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/weaveworks/tf-controller/internal/config"
 )
 
-const DefaultConfigMapName = "flux-system/branch-planner"
+const DefaultConfigMapName = "branch-planner"
 
 func (s *Server) readConfig(ctx context.Context) (*config.Config, error) {
 	configMap, err := config.ReadConfig(ctx, s.clusterClient, s.configMapRef)

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -41,8 +41,8 @@ LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controll
 
 RUN apk update
 
-RUN apk add --no-cache libcrypto3=3.1.1-r1 && \
-    apk add --no-cache libssl3=3.1.1-r1 && \
+RUN apk add --no-cache libcrypto3=3.1.1-r2 && \
+    apk add --no-cache libssl3=3.1.1-r2 && \
     apk add --no-cache ca-certificates tini git openssh-client gnupg && \
     apk add --no-cache libretls && \
     apk add --no-cache busybox

--- a/runner-azure.Dockerfile
+++ b/runner-azure.Dockerfile
@@ -38,8 +38,8 @@ LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controll
 
 RUN apk update
 
-RUN apk add --no-cache libcrypto3=3.1.1-r1 && \
-    apk add --no-cache libssl3=3.1.1-r1 && \
+RUN apk add --no-cache libcrypto3=3.1.1-r2 && \
+    apk add --no-cache libssl3=3.1.1-r2 && \
     apk add --no-cache ca-certificates tini git openssh-client gnupg && \
     apk add --no-cache libretls && \
     apk add --no-cache busybox

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -38,8 +38,8 @@ LABEL org.opencontainers.image.source="https://github.com/weaveworks/tf-controll
 
 RUN apk update
 
-RUN apk add --no-cache libcrypto3=3.1.1-r1 && \
-    apk add --no-cache libssl3=3.1.1-r1 && \
+RUN apk add --no-cache libcrypto3=3.1.1-r2 && \
+    apk add --no-cache libssl3=3.1.1-r2 && \
     apk add --no-cache ca-certificates tini git openssh-client gnupg && \
     apk add --no-cache libretls && \
     apk add --no-cache busybox


### PR DESCRIPTION
If `RUNTIME_NAMESPACE` is not defined, it falls back to `flux-system`.

Closes #765
Closes #767

References:
* https://github.com/weaveworks/tf-controller/issues/765