### PR TITLE
Fix source deletion when using branch planner

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	LabelKey               = "infra.weave.works/branch-planner"
-	LabelValue             = "true"
-	LabelPRIDKey           = "infra.weave.works/pr-id"
-	LabelOriginalNameKey   = "infra.weave.works/original-name"
-	AnnotationCommentIDKey = "infra.weave.works/comment-id"
+	LabelKey                = "infra.weave.works/branch-planner"
+	LabelValue              = "true"
+	LabelPRIDKey            = "infra.weave.works/pr-id"
+	LabelPrimaryResourceKey = "infra.weave.works/primary-resource"
+	AnnotationCommentIDKey  = "infra.weave.works/comment-id"
 
 	// DefaultNamespace will be used if RUNTIME_NAMESPACE is not defined.
 	DefaultNamespace = "flux-system"

--- a/internal/server/polling/server.go
+++ b/internal/server/polling/server.go
@@ -181,8 +181,8 @@ func (s *Server) reconcile(ctx context.Context, original *infrav1.Terraform, sou
 	// List the Terraform planner objects in the namespace of the original object
 	log.Info("listing Terraform objects...")
 	tfPlannerObjects, err := s.listTerraformObjects(ctx, original.Namespace, map[string]string{
-		bpconfig.LabelKey:             bpconfig.LabelValue,
-		bpconfig.LabelOriginalNameKey: original.Name,
+		bpconfig.LabelKey:                bpconfig.LabelValue,
+		bpconfig.LabelPrimaryResourceKey: original.Name,
 	})
 
 	// If an error occurs, wrap it with context information and return it.

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -152,7 +152,7 @@ func (s *Server) createLabels(labels map[string]string, originalName string, bra
 	}
 
 	labels[bpconfig.LabelKey] = bpconfig.LabelValue
-	labels[bpconfig.LabelOriginalNameKey] = originalName
+	labels[bpconfig.LabelPrimaryResourceKey] = originalName
 	labels[bpconfig.LabelPRIDKey] = prID
 
 	return labels


### PR DESCRIPTION
fixes #779 

We were listing all terraform objects in the cluster, causing the planner to check the existence of PR from another repo. Given that the PR did not exist since it was an ID from another repo, the planner deleted the derived resources thinking the PR had been closed/deleted