### PR TITLE
feat: add branch planner cli flag to helm chart values

### DIFF
--- a/charts/tf-controller/templates/planner-deployment.yaml
+++ b/charts/tf-controller/templates/planner-deployment.yaml
@@ -29,7 +29,12 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - args: []
+      - args:
+        - --log-encoding={{ .Values.logEncoding }}
+        - --log-level={{ .Values.logLevel }}
+        - --branch-polling-interval={{ .Values.branchPlanner.sourceInterval }}
+        - --polling-configmap={{ .Values.branchPlanner.configMap }}
+        - --polling-interval={{ .Values.branchPlanner.pollingInterval }}
         env:
           {{- include "pod-namespace" . | indent 8 }}
         image: "{{ .Values.branchPlanner.image.repository }}:{{ default .Chart.AppVersion .Values.branchPlanner.image.tag }}"

--- a/charts/tf-controller/values.yaml
+++ b/charts/tf-controller/values.yaml
@@ -175,3 +175,7 @@ branchPlanner:
     repository: ghcr.io/weaveworks/branch-planner
     pullPolicy: IfNotPresent
     tag: ""
+  configMap: branch-planner
+  pollingInterval: 30s
+  # Interval value to use for Source objects for branch planner Terraform objects.
+  sourceInterval: 30s


### PR DESCRIPTION
It was not possible to change cli parameters for the branch planner, now all values are expose through Helm values.

Closes #785

References:
* https://github.com/weaveworks/tf-controller/issues/785