### PR TITLE
patch: use allowedNamespaces in Branch Planner

### DIFF
--- a/charts/tf-controller/templates/planner-deployment.yaml
+++ b/charts/tf-controller/templates/planner-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - --branch-polling-interval={{ .Values.branchPlanner.sourceInterval }}
         - --polling-configmap={{ .Values.branchPlanner.configMap }}
         - --polling-interval={{ .Values.branchPlanner.pollingInterval }}
+        - --allowed-namespaces={{ include "tf-controller.runner.allowedNamespaces" . | fromJsonArray | join "," }}
         env:
           {{- include "pod-namespace" . | indent 8 }}
         image: "{{ .Values.branchPlanner.image.repository }}:{{ default .Chart.AppVersion .Values.branchPlanner.image.tag }}"

--- a/cmd/branch-planner/flags.go
+++ b/cmd/branch-planner/flags.go
@@ -16,6 +16,8 @@ type applicationOptions struct {
 	pollingInterval       time.Duration
 	branchPollingInterval time.Duration
 
+	allowedNamespaces []string
+
 	logOptions logger.Options
 	aclOptions acl.Options
 
@@ -38,6 +40,11 @@ func parseFlags() *applicationOptions {
 	flag.DurationVar(&opts.branchPollingInterval,
 		"branch-polling-interval", 0,
 		"Interval to use for PR branch sources (default is to use the value of --polling-interval).")
+
+	flag.StringSliceVar(&opts.allowedNamespaces,
+		"allowed-namespaces",
+		[]string{},
+		"Allowed namespaced. If it's empty, all namespaces are allowed for the planner. If it's not empty, only resources in the defined namespaces are allowed.")
 
 	opts.logOptions.BindFlags(flag.CommandLine)
 	opts.aclOptions.BindFlags(flag.CommandLine)

--- a/internal/server/polling/option.go
+++ b/internal/server/polling/option.go
@@ -65,3 +65,10 @@ func WithNoCrossNamespaceRefs(deny bool) Option {
 		return nil
 	}
 }
+
+func WithAllowedNamespaces(namespaces []string) Option {
+	return func(s *Server) error {
+		s.allowedNamespaces = namespaces
+		return nil
+	}
+}


### PR DESCRIPTION
If a Terraform resources is not in a namespace defined in the allowedNamespaces list, it will never be reconciled as the runner has no permissions in that namespace.

If someone creates a Terraform object in a "forbidden" namespace and configures that namespace to be watched by the Branch Planner, it would create new Terraform resources for each pull request, but none of them would be ever reconciled. If a repository has 10-20 open pull requests already, then we would create 10-20 dead Branch Planner Terraform objects with corresponding Secret and Source. That's a huge waste of resources.

This patch aims to fix this by using the same allowedNamespaces list.

closes #804

References:
* https://github.com/weaveworks/tf-controller/issues/804