### PR TITLE
patch: static replica count for branch planner

### DIFF
--- a/charts/tf-controller/templates/planner-deployment.yaml
+++ b/charts/tf-controller/templates/planner-deployment.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "planner.labels" . | nindent 4 }}
   name: {{ include "planner.fullname" . }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  # Planner can't be scaled yet.
+  replicas: 1
   selector:
     matchLabels:
       {{- include "planner.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Branch Planner is not scalable yet. If someone tries to scale it, then they will see unexpected behavior.

Closes #807

References:
* https://github.com/weaveworks/tf-controller/issues/807