### PR TITLE
Add flag --allow-cross-namespace-refs to tf-controller and branch-planner

### DIFF
--- a/cmd/branch-planner/flags.go
+++ b/cmd/branch-planner/flags.go
@@ -68,7 +68,7 @@ func parseFlags() *applicationOptions {
 		opts.watchNamespace = opts.runtimeNamespace
 	}
 
-	// as in ../manager/main.go, this is the case where --no-cross-namespace-refs can be different and not overridden.
+	// as in ../manager/main.go, this checks for the case where the --no-cross-namespace-refs value is used.
 	if !flag.CommandLine.Changed("allow-cross-namespace-refs") && flag.CommandLine.Changed("no-cross-namespace-refs") {
 		opts.noCrossNamespaceRefs = aclOptions.NoCrossNamespaceRefs
 	} else {

--- a/cmd/branch-planner/polling.go
+++ b/cmd/branch-planner/polling.go
@@ -16,7 +16,7 @@ func startPollingServer(ctx context.Context, log logr.Logger, clusterClient clie
 		polling.WithConfigMap(opts.pollingConfigMap),
 		polling.WithPollingInterval(opts.pollingInterval),
 		polling.WithBranchPollingInterval(opts.branchPollingInterval),
-		polling.WithNoCrossNamespaceRefs(opts.aclOptions.NoCrossNamespaceRefs),
+		polling.WithNoCrossNamespaceRefs(opts.noCrossNamespaceRefs),
 	)
 	if err != nil {
 		return fmt.Errorf("problem configuring the polling server: %w", err)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -205,7 +205,7 @@ func main() {
 	//     -                |  f   |   t*  |  f |
 	//
 	// '-' means "not supplied"
-	// * is the only place the value of `allowCrossNamespaceRefs` (as defaulted or set by the flag) needs adjusting.
+	// * is the only place the value of `--no-cross-namespace-refs` is used, so check for this case.
 	if !flag.CommandLine.Changed("allow-cross-namespace-refs") && flag.CommandLine.Changed("no-cross-namespace-refs") {
 		allowCrossNamespaceRefs = !aclOptions.NoCrossNamespaceRefs
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -93,6 +93,7 @@ func main() {
 		allowBreakTheGlass        bool
 		clusterDomain             string
 		aclOptions                acl.Options
+		allowCrossNamespaceRefs   bool
 		usePodSubdomainResolution bool
 	)
 
@@ -120,7 +121,12 @@ func main() {
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
+	// this adds the flag `--no-cross-namespace-refs`, for backward-compatibility of deployments that use that Flux-like flag.
 	aclOptions.BindFlags(flag.CommandLine)
+	// this flag exists so that the default is to _disallow_ cross-namespace refs. If supplied, it'll override `--no-cross-namespace-refs`; in other words, you can supply `--allow-cross-namespace-refs` with or without a value, and it will be observed.
+	flag.BoolVar(&allowCrossNamespaceRefs, "allow-cross-namespace-refs", false,
+		"Enable following cross-namespace references. Overrides --no-cross-namespace-refs")
+
 	flag.Parse()
 
 	ctrl.SetLogger(logger.NewLogger(logOptions))
@@ -190,6 +196,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Cross-namespace refs enabled:
+	//
+	// --allow... \ --no... | true | false |  - |
+	// ---------------------|------|-------|----|
+	//     true             |  t   |   t   |  t |
+	//     false            |  f   |   f   |  f |
+	//     -                |  f   |   t*  |  f |
+	//
+	// '-' means "not supplied"
+	// * is the only place the value of `allowCrossNamespaceRefs` (as defaulted or set by the flag) needs adjusting.
+	if !flag.CommandLine.Changed("allow-cross-namespace-refs") && flag.CommandLine.Changed("no-cross-namespace-refs") {
+		allowCrossNamespaceRefs = !aclOptions.NoCrossNamespaceRefs
+	}
+
 	reconciler := &controllers.TerraformReconciler{
 		Client:                    mgr.GetClient(),
 		Scheme:                    mgr.GetScheme(),
@@ -202,7 +222,7 @@ func main() {
 		RunnerGRPCMaxMessageSize:  runnerGRPCMaxMessageSize,
 		AllowBreakTheGlass:        allowBreakTheGlass,
 		ClusterDomain:             clusterDomain,
-		NoCrossNamespaceRefs:      aclOptions.NoCrossNamespaceRefs,
+		NoCrossNamespaceRefs:      !allowCrossNamespaceRefs,
 		UsePodSubdomainResolution: usePodSubdomainResolution,
 	}
 


### PR DESCRIPTION
With reference to [ADR 002](https://github.com/weaveworks/tf-controller/blob/main/docs/adr/0002-deny-cross-ns-by-default.md):

This adds the flag --allow-cross-namespace-refs, which defaults to `false` (do not allow cross namespace refs), and overrides the flag `--no-cross-namespace-refs` which is borrowed from Flux.

The rationale is that it's secure by default to not allow cross-namespace refs, and to make people explicitly allow them with the flag. It's early enough in the life of tf-controller to make this breaking change -- people using cross-namespace refs will just need to add the flag into their config.

Since people may already be using the flag `--no-cross-namespace-refs`, I've kept it. If `--allow-cross-namespace-refs` _is not_ supplied, and `--no-cross-namespace-refs` _is_ supplied, the latter will take effect. In practice this only matters if you pass `--no-cross-namespace-refs=false`, i.e., explicitly enable them via a double negative ("don't not enable them .."), since all other cases are the same as not passing either flag.

The implementation differs slightly between cmd/manager/ and cmd/branch-planner, just because of how these deal with flags. I've tried to follow a similar scheme, by passing a field `.NoCrossNamespaceRefs` to components. This also means a smaller change here, since that's how the option was conveyed when there was only `--no-cross-namespace-refs`.

Last thing: I did not write tests for this, on the basis that it's just flag parsing. I think it'd be reasonable to ask for some tests to make sure the right value ends up in `.NoCrossNamespaceRefs`, but I leave that decision to the reviewer.
