### PR TITLE
build: remove `nsswitch.conf` creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,6 @@ RUN apk add --no-cache libcrypto3=3.1.2-r0 && \
 
 COPY --from=builder /workspace/tf-controller /usr/local/bin/
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN addgroup --gid 65532 -S controller && adduser --uid 65532 -S controller -G controller
 
 USER 65532:65532

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -49,10 +49,6 @@ RUN apk add --no-cache libcrypto3=3.1.2-r0 && \
 
 COPY --from=builder /workspace/branch-planner /usr/local/bin/
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN addgroup --gid 65532 -S controller && adduser --uid 65532 -S controller -G controller
 
 USER 65532:65532

--- a/runner-azure.Dockerfile
+++ b/runner-azure.Dockerfile
@@ -54,10 +54,6 @@ RUN pip install --upgrade pip && \
 COPY --from=builder /workspace/tf-runner /usr/local/bin/
 COPY --from=builder /workspace/terraform /usr/local/bin/
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN addgroup --gid 65532 -S runner && adduser --uid 65532 -S runner -G runner && chmod +x /usr/local/bin/terraform
 
 USER 65532:65532

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -47,10 +47,6 @@ RUN apk add --no-cache libcrypto3=3.1.2-r0 && \
 COPY --from=builder /workspace/tf-runner /usr/local/bin/
 COPY --from=builder /workspace/terraform /usr/local/bin/
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN addgroup --gid 65532 -S runner && adduser --uid 65532 -S runner -G runner && chmod +x /usr/local/bin/terraform
 
 USER 65532:65532


### PR DESCRIPTION
Since Alpine 3.16, this is included within the base image and thus no longer required.

Refer to https://git.alpinelinux.org/aports/commit/?id=348653a9ba0701e8e968b3344e72313a9ef334e4 for more information.