### PR TITLE
chore: post blocked issues on watermelon slack on Mon and Thu

### DIFF
--- a/.github/workflows/blocked-reminder.yaml
+++ b/.github/workflows/blocked-reminder.yaml
@@ -1,0 +1,82 @@
+name: Wild Watermelon Blocked Issue Reminder on Slack
+on:
+  workflow_dispatch:
+  schedule:
+    # Poke on Monday to kick off the week, and on Thu so we have time to poke
+    # others on Fri.
+    - cron: '0 15 * * 1,4'
+
+jobs:
+  issue-list:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List Issues
+        uses: actions/github-script@v6
+        id: list-issues
+        with:
+          script: |
+            // Use the label that filters down issues the most in the
+            // initial query.
+            const baseLabel = 'blocked';
+
+            // "AND" logic, so all labels has to be on the issue.
+            // This is required because the GrqphQL API uses "OR" if we
+            // specify more than one label in the query.
+            const extraLabels = ['team/wild-watermelon'];
+
+            const query = `query($owner:String!, $name:String!, $label:String!) {
+              repository(owner:$owner, name:$name){
+                issues(first:100, labels: [$label], states: [OPEN]) {
+                  nodes {
+                    title, number, url,
+                    labels(first: 20) {
+                      nodes { name id }
+                    }
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo,
+              label: baseLabel
+            }
+            const result = await github.graphql(query, variables)
+
+            const lines = result.repository.issues.nodes.map(issue => {
+              const labels = issue.labels.nodes.map(label => label.name)
+
+              const matchingLabels = labels.filter(label => {
+                return extraLabels.indexOf(label) !== -1;
+              });
+
+              if (matchingLabels.length !== extraLabels.length) {
+                return null;
+              }
+
+              return [
+                " * ",
+                "<", issue.url, "|", issue.title.replace(/[<>]/g, ''), ">",
+                " (", labels.map(n => '`'+n+'`').join(", "), ")"
+              ].join('')
+            }).filter(line => line !== null)
+
+            if (lines.length < 1) {
+              return ""
+            }
+
+            const header = [
+              ":old-man-yells-at-cloud: All issues on", "`" + context.repo.owner + "/" + context.repo.repo + "`",
+              "marked with:", [baseLabel, ...extraLabels].map(n => '`'+n+'`').join(", ")
+            ].join(" ")
+
+            return [header, lines.join("\n")].join("\n\n")
+          result-encoding: string
+      - name: Send issues to Slack
+        uses: archive/github-actions-slack@d9dae40827adf93bddf939db6552d1e392259d7d # v2.7.0
+        if: ${{ steps.list-issues.outputs.result != '' }}
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.WEAVEWORKS_SLACK_GENERICBOT_TOKEN }}
+          slack-channel: C0586V3N0BG # team-wild-watermelon
+          slack-text: ${{steps.list-issues.outputs.result}}
+          slack-optional-icon_url: "https://avatars.githubusercontent.com/u/9976052"


### PR DESCRIPTION
Send a slack message with all `blocked` issues to Wild Watermelon's slack channel.

Schedule: Mon and Thu at 3pm UTC.

Workflow can be triggered on the GitHub UI manually.