### PR TITLE
patch: back-backport v0.14 break-the-glass changes

### DIFF
--- a/api/v1alpha1/terraform_types.go
+++ b/api/v1alpha1/terraform_types.go
@@ -37,11 +37,12 @@ const (
 	CACertSecretName = "tf-controller.tls"
 	// RunnerTLSSecretName is the name of the secret containing a TLS cert that will be written to
 	// the namespace in which a terraform runner is created
-	RunnerTLSSecretName   = "terraform-runner.tls"
-	RunnerLabel           = "infra.contrib.fluxcd.io/terraform"
-	GitRepositoryIndexKey = ".metadata.gitRepository"
-	BucketIndexKey        = ".metadata.bucket"
-	OCIRepositoryIndexKey = ".metadata.ociRepository"
+	RunnerTLSSecretName     = "terraform-runner.tls"
+	RunnerLabel             = "infra.contrib.fluxcd.io/terraform"
+	GitRepositoryIndexKey   = ".metadata.gitRepository"
+	BucketIndexKey          = ".metadata.bucket"
+	OCIRepositoryIndexKey   = ".metadata.ociRepository"
+	BreakTheGlassAnnotation = "break-the-glass.tf-controller/requestedAt"
 )
 
 type ReadInputsFromSecretSpec struct {
@@ -236,6 +237,11 @@ type TerraformSpec struct {
 	// Enterprise is the enterprise configuration placeholder.
 	// +optional
 	Enterprise *apiextensionsv1.JSON `json:"enterprise,omitempty"`
+
+	// BreakTheGlass specifies if the reconciliation should stop
+	// and allow interactive shell in case of emergency.
+	// +optional
+	BreakTheGlass bool `json:"breakTheGlass,omitempty"`
 }
 
 type CloudSpec struct {

--- a/charts/tf-controller/templates/crds.yaml
+++ b/charts/tf-controller/templates/crds.yaml
@@ -113,6 +113,10 @@ spec:
                   - name
                   type: object
                 type: array
+              breakTheGlass:
+                description: BreakTheGlass specifies if the reconciliation should
+                  stop and allow interactive shell in case of emergency.
+                type: boolean
               cliConfigSecretRef:
                 description: SecretReference represents a Secret Reference. It has
                   enough information to retrieve secret in any namespace
@@ -5065,7 +5069,7 @@ spec:
                   type: object
                 type: array
               branchPlanner:
-                description: BarnchPlanner configuration.
+                description: BranchPlanner configuration.
                 properties:
                   enablePathScope:
                     description: EnablePathScope specifies if the Branch Planner should

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -111,6 +111,10 @@ spec:
                   - name
                   type: object
                 type: array
+              breakTheGlass:
+                description: BreakTheGlass specifies if the reconciliation should
+                  stop and allow interactive shell in case of emergency.
+                type: boolean
               cliConfigSecretRef:
                 description: SecretReference represents a Secret Reference. It has
                   enough information to retrieve secret in any namespace
@@ -5063,7 +5067,7 @@ spec:
                   type: object
                 type: array
               branchPlanner:
-                description: BarnchPlanner configuration.
+                description: BranchPlanner configuration.
                 properties:
                   enablePathScope:
                     description: EnablePathScope specifies if the Branch Planner should


### PR DESCRIPTION
We changed `v1alpha1` in v0.14 to backport the break-the-glass feature, but the added fields don't exist in v0.15+ for `v1alpha1` and that can break upgrade processes.

Closes #866

References:
* https://github.com/weaveworks/tf-controller/issues/866
* https://github.com/weaveworks/tf-controller/pull/855