### PR TITLE
ci: Add OpenSSF Scorecard GH Action

### DIFF
--- a/.github/workflows/ossf.yaml
+++ b/.github/workflows/ossf.yaml
@@ -1,0 +1,49 @@
+name: ossf
+on:
+  branch_protection_rule:
+  push:
+    branches: [ main ]
+  schedule:
+    # Weekly on Saturdays.
+    - cron:  '30 1 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed if using Code scanning alerts
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # required for Code scanning alerts
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@e4262713b504983e61c7728f5452be240d9385a7 # v2.14.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Relates to: https://github.com/weaveworks/tf-controller/issues/859

Configured to run:
- when the branch protection rule for the default branch changes
- when pushing to main
- every Saturday morning
- on demand (so that we can invoke it for testing)