### PR TITLE
ci: Run `go vet` on CI

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,31 @@
+name: verify
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'MAINTAINERS'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+permissions:
+  contents: read # for actions/checkout to fetch code
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
+      - name: Verify
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: verify
+verify: fmt vet manifests api-docs
+	@if [ ! "$$(git status --porcelain --untracked-files=no)" = "" ]; then \
+		echo "working directory is dirty:"; \
+		git --no-pager diff; \
+		exit 1; \
+	fi
+
 download-crd-deps:
 	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml > config/crd/bases/gitrepositories.yaml
 	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml > config/crd/bases/buckets.yaml

--- a/docs/References/terraform.md
+++ b/docs/References/terraform.md
@@ -1756,7 +1756,8 @@ BranchPlanner
 </em>
 </td>
 <td>
-<p>BarnchPlanner configuration.</p>
+<em>(Optional)</em>
+<p>BranchPlanner configuration.</p>
 </td>
 </tr>
 </table>
@@ -2291,7 +2292,8 @@ BranchPlanner
 </em>
 </td>
 <td>
-<p>BarnchPlanner configuration.</p>
+<em>(Optional)</em>
+<p>BranchPlanner configuration.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Relates to #859 

Added a new make target that invokes `go vet` and a CI workflow to call that target.