### PR TITLE
fix tfctl install --export not separating yaml objects properly

### DIFF
--- a/tfctl/install.go
+++ b/tfctl/install.go
@@ -47,13 +47,16 @@ func (c *CLI) Install(out io.Writer, version string, export bool) (err error) {
 		spinner.Start()
 	}
 
-	for _, k := range []string{"crds", "rbac", "deployment"} {
+	for i, k := range []string{"crds", "rbac", "deployment"} {
 		data, err := download(version, k)
 		if err != nil {
 			return err
 		}
 
 		if export {
+			if i > 0 {
+				fmt.Fprintln(out, "---")
+			}
 			fmt.Fprintln(out, string(data))
 			continue
 		}


### PR DESCRIPTION
Hi, I'm trying to fix `tfctl install --export` so I can deploy tf-controller via plain k8s manifests, like Flux (vs the HelmRelease offered in the guides).

After fixing this `---` issue this is the only error left:

```
➜  tf-controller git:(fix-tfctl-install) ✗ k apply -f tfctrl.yml
serviceaccount/tf-controller unchanged
serviceaccount/tf-runner unchanged
role.rbac.authorization.k8s.io/tf-leader-election-role unchanged
clusterrole.rbac.authorization.k8s.io/tf-manager-role configured
clusterrole.rbac.authorization.k8s.io/tf-runner-role unchanged
rolebinding.rbac.authorization.k8s.io/tf-leader-election-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/tf-cluster-reconciler unchanged
clusterrolebinding.rbac.authorization.k8s.io/tf-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/tf-runner-rolebinding unchanged
deployment.apps/tf-controller configured
The CustomResourceDefinition "terraforms.infra.contrib.fluxcd.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
➜  tf-controller git:(fix-tfctl-install) ✗ 
```