### PR TITLE
fix: 000011_workspace_no_outputs_test test

### DIFF
--- a/controllers/cleaner_test.go
+++ b/controllers/cleaner_test.go
@@ -1,37 +1,19 @@
 package controllers
 
 import (
-	"sync"
+	"context"
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type resourceToBeDeleted struct {
-	Namespace string
-	Name      string
-	Object    client.Object
-}
+func waitResourceToBeDelete(g gomega.Gomega, resource client.Object) {
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: resource.GetNamespace(), Name: resource.GetName()}
 
-func waitResourceToBeDelete(g gomega.Gomega, resource resourceToBeDeleted) {
+	g.Expect(k8sClient.Delete(ctx, resource)).Should(gomega.Succeed())
 	g.Eventually(func() error {
-		key := types.NamespacedName{Namespace: resource.Namespace, Name: resource.Name}
-
-		return k8sClient.Get(ctx, key, resource.Object)
+		return k8sClient.Get(ctx, key, resource)
 	}, timeout, interval).ShouldNot(gomega.Succeed())
-}
-
-func waitResourcesToBeDelete(g gomega.Gomega, resources []resourceToBeDeleted) {
-	var wg sync.WaitGroup
-
-	for _, resource := range resources {
-		wg.Add(1)
-		go func(resource resourceToBeDeleted) {
-			waitResourceToBeDelete(g, resource)
-			wg.Done()
-		}(resource)
-	}
-
-	wg.Wait()
 }

--- a/controllers/cleaner_test.go
+++ b/controllers/cleaner_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"sync"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type resourceToBeDeleted struct {
+	Namespace string
+	Name      string
+	Object    client.Object
+}
+
+func waitResourceToBeDelete(g gomega.Gomega, resource resourceToBeDeleted) {
+	g.Eventually(func() error {
+		key := types.NamespacedName{Namespace: resource.Namespace, Name: resource.Name}
+
+		return k8sClient.Get(ctx, key, resource.Object)
+	}, timeout, interval).ShouldNot(gomega.Succeed())
+}
+
+func waitResourcesToBeDelete(g gomega.Gomega, resources []resourceToBeDeleted) {
+	var wg sync.WaitGroup
+
+	for _, resource := range resources {
+		wg.Add(1)
+		go func(resource resourceToBeDeleted) {
+			waitResourceToBeDelete(g, resource)
+			wg.Done()
+		}(resource)
+	}
+
+	wg.Wait()
+}

--- a/controllers/tc000010_no_outputs_test.go
+++ b/controllers/tc000010_no_outputs_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
@@ -23,9 +22,9 @@ func Test_000010_no_outputs_test(t *testing.T) {
 	Spec("This spec describes the behaviour of a Terraform resource with no backend, and `auto` approve.")
 	It("should be reconciled to have available outputs.")
 
-	var (
+	const (
 		sourceName    = "test-tf-controller-no-output"
-		terraformName = "helloworld-no-outputs-" + rand.String(6)
+		terraformName = "helloworld-no-outputs"
 	)
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -49,7 +48,14 @@ func Test_000010_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      sourceName,
+			Object:    &sourcev1.GitRepository{},
+		})
+	}()
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -99,7 +105,14 @@ spec:
 
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      terraformName,
+			Object:    &infrav1.Terraform{},
+		})
+	}()
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000010_no_outputs_test.go
+++ b/controllers/tc000010_no_outputs_test.go
@@ -48,14 +48,7 @@ func Test_000010_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      sourceName,
-			Object:    &sourcev1.GitRepository{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -105,14 +98,7 @@ spec:
 
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      terraformName,
-			Object:    &infrav1.Terraform{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000011_bad_tar_gz_no_outputs_test.go
+++ b/controllers/tc000011_bad_tar_gz_no_outputs_test.go
@@ -71,14 +71,7 @@ func Test_000011_bad_tar_gz_no_outputs_test(t *testing.T) {
 	}
 	It("should be updated successfully.")
 	g.Expect(k8sClient.Status().Update(ctx, &testRepo)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      sourceName,
-			Object:    &sourcev1.GitRepository{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("a Terraform object with auto approve, and attaching it to the bad GitRepository resource.")
 	By("creating a new TF resource and attaching to the bad repo via `sourceRef`.")
@@ -102,14 +95,7 @@ spec:
 
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      terraformName,
-			Object:    &infrav1.Terraform{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000011_bad_tar_gz_no_outputs_test.go
+++ b/controllers/tc000011_bad_tar_gz_no_outputs_test.go
@@ -71,7 +71,14 @@ func Test_000011_bad_tar_gz_no_outputs_test(t *testing.T) {
 	}
 	It("should be updated successfully.")
 	g.Expect(k8sClient.Status().Update(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      sourceName,
+			Object:    &sourcev1.GitRepository{},
+		})
+	}()
 
 	Given("a Terraform object with auto approve, and attaching it to the bad GitRepository resource.")
 	By("creating a new TF resource and attaching to the bad repo via `sourceRef`.")
@@ -95,7 +102,14 @@ spec:
 
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      terraformName,
+			Object:    &infrav1.Terraform{},
+		})
+	}()
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000011_workspace_no_outputs_test.go
+++ b/controllers/tc000011_workspace_no_outputs_test.go
@@ -48,14 +48,7 @@ func Test_000011_workspace_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      sourceName,
-			Object:    &sourcev1.GitRepository{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -106,14 +99,7 @@ spec:
 
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      terraformName,
-			Object:    &infrav1.Terraform{},
-		})
-	}()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000020_with_workspace_no_outputs_test.go
+++ b/controllers/tc000020_with_workspace_no_outputs_test.go
@@ -49,14 +49,7 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      sourceName,
-			Object:    &sourcev1.GitRepository{},
-		})
-	}()
+	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -115,14 +108,7 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
-		waitResourceToBeDelete(g, resourceToBeDeleted{
-			Namespace: "flux-system",
-			Name:      terraformName,
-			Object:    &infrav1.Terraform{},
-		})
-	}()
+	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000020_with_workspace_no_outputs_test.go
+++ b/controllers/tc000020_with_workspace_no_outputs_test.go
@@ -49,7 +49,14 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      sourceName,
+			Object:    &sourcev1.GitRepository{},
+		})
+	}()
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -108,7 +115,14 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer func() {
+		g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed())
+		waitResourceToBeDelete(g, resourceToBeDeleted{
+			Namespace: "flux-system",
+			Name:      terraformName,
+			Object:    &infrav1.Terraform{},
+		})
+	}()
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}


### PR DESCRIPTION
1. It used the same resource name as 000010 test.
2. We requested resources to be deleted, but we didn't wait them to be deleted.

fixes #908

References:
* https://github.com/weaveworks/tf-controller/issues/908