### PR TITLE
Adds Troubleshooting Section and tip to drift detection page

### DIFF
--- a/docs/use_tf_controller/to_detect_drifts_only_without_plan_or_apply.md
+++ b/docs/use_tf_controller/to_detect_drifts_only_without_plan_or_apply.md
@@ -17,3 +17,10 @@ spec:
     name: helloworld
     namespace: flux-system
 ```
+
+## Troubleshooting
+
+### When Terraform resource detects drift, but no plan is generated for approval
+
+In this situation, you may not have `spec.approvePlan` set to `disable`. Try setting `spec.approvePlan: auto` and using `tfctl replan` to trigger a replan.
+After the drift disappears, you can set the `spec.approvePlan: ""` to get into the manual mode again.


### PR DESCRIPTION
This PR adds a few lines of documentation and a new troubleshooting section to the ["o detect drifts only without plan or apply" page](https://weaveworks.github.io/tf-controller/use_tf_controller/to_detect_drifts_only_without_plan_or_apply/). The included tip is based on a recent user example.