### PR TITLE
fix: controllers/tc00004x tests

### DIFF
--- a/controllers/tc000040_controlled_outputs_test.go
+++ b/controllers/tc000040_controlled_outputs_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -50,7 +48,7 @@ func Test_000040_controlled_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -111,7 +109,7 @@ func Test_000040_controlled_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000041_all_outputs_test.go
+++ b/controllers/tc000041_all_outputs_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -50,7 +48,7 @@ func Test_000041_all_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -107,7 +105,7 @@ func Test_000041_all_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000042_output_name_contains_dot_test.go
+++ b/controllers/tc000042_output_name_contains_dot_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -51,7 +49,7 @@ func Test_000042_output_name_contains_dot_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -111,7 +109,7 @@ func Test_000042_output_name_contains_dot_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000043_controlled_outputs_should_be_reconciled_test.go
+++ b/controllers/tc000043_controlled_outputs_should_be_reconciled_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -49,7 +47,7 @@ func Test_000043_controlled_outputs_should_be_reconciled_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -108,7 +106,7 @@ func Test_000043_controlled_outputs_should_be_reconciled_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000044_plan_only_mode_test.go
+++ b/controllers/tc000044_plan_only_mode_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -133,7 +132,6 @@ func Test_000044_plan_only_mode_test(t *testing.T) {
 
 	g.Expect(planOutput.Name).To(Equal("tfplan-default-" + terraformName))
 	g.Expect(planOutput.Namespace).To(Equal("flux-system"))
-	fmt.Printf(" --- %s\n", createdHelloWorldTF.UID)
 	g.Expect(string(planOutput.OwnerReferences[0].UID)).To(Equal(string(createdHelloWorldTF.UID)))
 	g.Expect(string(planOutput.Data["tfplan"])).To(ContainSubstring(`+ hello_world = "Hello, World!"`))
 


### PR DESCRIPTION
They passed constistently running them 3 times in a row without break, so no main suit cleanup.

```
❯ go test ./controllers -parallel 1 -count=3 -test.run Test_00004
ok      github.com/weaveworks/tf-controller/controllers 22.412s
```

Fixes #904

References:
* https://github.com/weaveworks/tf-controller/issues/904