### PR TITLE
experiment: break up test jobs

### DIFF
--- a/.github/workflows/targeted-test.yaml
+++ b/.github/workflows/targeted-test.yaml
@@ -1,0 +1,37 @@
+on:
+  workflow_call:
+    inputs:
+      pattern:
+        required: true
+        type: string
+jobs:
+  targeted-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Go cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+      - name: Setup Terraform
+        run: |
+          export TF_VERSION=1.3.7
+          wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
+          unzip -q terraform_${TF_VERSION}_linux_amd64.zip
+          mv terraform $(which terraform)
+          terraform --version
+      - name: Setup Kustomize
+        if: "!github.event.pull_request.head.repo.fork"
+        uses: fluxcd/pkg/actions/kustomize@main
+      - name: Run tests
+        run: |
+          make install-envtest
+          make TARGET="${{ inputs.pattern }}"     target-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,35 @@ on:
       - main
 
 jobs:
-  test:
+  test-1x-2x:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0000[12]"
+  test-3x-5x:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0000[345]"
+  test-6x-9x:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0000[6789]"
+  test-1xx:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0001"
+  test-2xx:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0002"
+  test-3xx:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0003"
+  test-99xx:
+    uses: ./.github/workflows/targeted-test.yaml
+    with:
+      pattern: "^Test_0099"
+  internal:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,8 +72,4 @@ jobs:
       - name: Run tests
         run: |
           make install-envtest
-          make TARGET="^Test_0000"     target-test
-          make TARGET="^Test_000[12]"  target-test
-          make TARGET="^Test_0003"     target-test
-          make TARGET="^Test_0099"     target-test
           make test-internal


### PR DESCRIPTION
Benefits:
- Easier to re-run failed jobs, it does not re-run all of them
- Each group has it's own envtest
- Because it's parallel, it's faster (see comment)


related to #865 