### PR TITLE
fix: controllers/tc00005x tests and the manual approval stuck in loop bug

### DIFF
--- a/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
+++ b/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -52,7 +50,7 @@ func Test_000050_plan_and_manual_approve_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -105,7 +103,7 @@ func Test_000050_plan_and_manual_approve_no_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
+++ b/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
@@ -1,5 +1,3 @@
-//go:build disabled
-
 package controllers
 
 import (
@@ -195,6 +193,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
+	defer waitResourceToBeDelete(g, &tfplanSecret)
 
 	By("changing source to a new revision")
 	testRepo.Status = sourcev1.GitRepositoryStatus{

--- a/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
+++ b/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
@@ -1,4 +1,4 @@
-//go:build flaky
+//go:build disabled
 
 package controllers
 
@@ -52,7 +52,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -105,7 +105,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}
@@ -257,7 +257,7 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 			return nil
 		}
 		for _, c := range createdHelloWorldTF.Status.Conditions {
-			if c.Type == "Apply" {
+			if c.Type == infrav1.ConditionTypeApply {
 				return map[string]interface{}{
 					"Type":            c.Type,
 					"Reason":          c.Reason,

--- a/controllers/tc000052_plan_and_manual_approve_with_files_test.go
+++ b/controllers/tc000052_plan_and_manual_approve_with_files_test.go
@@ -1,4 +1,4 @@
-//go:build flaky
+//go:build disabled
 
 package controllers
 
@@ -52,7 +52,7 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -129,7 +129,7 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000052_plan_and_manual_approve_with_files_test.go
+++ b/controllers/tc000052_plan_and_manual_approve_with_files_test.go
@@ -1,5 +1,3 @@
-//go:build disabled
-
 package controllers
 
 import (
@@ -219,6 +217,7 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
+	defer waitResourceToBeDelete(g, &tfplanSecret)
 
 	time.Sleep(10 * time.Second)
 

--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -130,11 +130,8 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	log.Info(fmt.Sprintf(">> Started Generation: %d", terraform.GetGeneration()))
 
-	// Initialize the runtime patcher with the current version of the object.
-	patcher := patch.NewSerialPatcher(&terraform, r.Client)
-
 	defer func() {
-		if err := r.finalizeStatus(ctx, &terraform, patcher); err != nil {
+		if err := r.finalizeStatus(ctx, &terraform); err != nil {
 			retErr = kerrors.NewAggregate([]error{retErr, err})
 		}
 
@@ -819,7 +816,10 @@ func (r *TerraformReconciler) event(ctx context.Context, terraform infrav1.Terra
 	r.EventRecorder.AnnotatedEventf(&terraform, metadata, eventType, reason, msg)
 }
 
-func (r *TerraformReconciler) finalizeStatus(ctx context.Context, obj *infrav1.Terraform, patcher *patch.SerialPatcher) error {
+func (r *TerraformReconciler) finalizeStatus(ctx context.Context, obj *infrav1.Terraform) error {
+	// Initialize the runtime patcher with the current version of the object.
+	patcher := patch.NewSerialPatcher(obj, r.Client)
+
 	if v, ok := meta.ReconcileAnnotationValue(obj.GetAnnotations()); ok {
 		obj.Status.LastHandledReconcileAt = v
 	}


### PR DESCRIPTION
fix: controllers/tc00005x tests

Closes #905

---

fix: reconcile stuck in a loop with manual approval

After a bit of poking, if I remove all changed from the commit, except
the `patcher := ...` and the `patcher.Patch` call (so the
`finalizeStatus` does literally nothing, but patches the "expected
nothing"), it still causes an issue.

If I keep everything from the commit, but move the `patcher :=` line
into the `defer` function, tests are happy.

We already have status patching everywhere (without this commit
everything worked). The Patcher in this commit should just patch the
diff calculated in finalizeStatus.

I assume it a weird issue how the whole codebase tosses around the
`&terraform` reference and makes Patch calls somewhere else in the State
Machine.


Closes #890