### PR TITLE
fix: controller test 201 and fix test clean-up

### DIFF
--- a/controllers/cleaner_test.go
+++ b/controllers/cleaner_test.go
@@ -29,7 +29,7 @@ func waitResourceToBeDelete(g gomega.Gomega, resource client.Object) {
 		return k8sClient.Get(ctx, key, resource)
 	}, cleanupTimeoutSeconds, interval).ShouldNot(gomega.Succeed())
 
-	if resource.GetObjectKind().GroupVersionKind().Kind == infrav1.TerraformKind {
+	if _, ok := resource.(*infrav1.Terraform); ok {
 		waitDefaultSecretsToBeDeletedForTerraform(g, resource)
 	}
 }

--- a/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
+++ b/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -44,7 +42,7 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	By("setting the git repo status object, the URL, and the correct checksum")
 	testRepo.Status = sourcev1.GitRepositoryStatus{
@@ -101,7 +99,7 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the hello world TF gets created")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}


### PR DESCRIPTION
```
❯ go test ./controllers -parallel=1 -count=3 -test.run="Test_000201"
ok      github.com/weaveworks/tf-controller/controllers 99.224s
```

For the cleanup:
Sadly `resource.GetObjectKind().GroupVersionKind().Kind` is an empty string, so it didn't work at all.

Fixes #947

References:
* https://github.com/weaveworks/tf-controller/issues/947