### PR TITLE
docs: update least required permissions for a github api token

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ k8s_resource('chart-tf-controller',
   labels=["deployments"],
   new_name='controller')
 
-k8s_resource('chart-tf-controller-planner',
+k8s_resource('chart-tf-controller-branch-planner',
   labels=["deployments"],
   new_name='branch-planner')
 

--- a/docs/branch_planner/least-required-permissions.md
+++ b/docs/branch_planner/least-required-permissions.md
@@ -9,9 +9,7 @@ any additional permissions.
 
 For private repositories the following permissions are required:
 
-* `Issues` with Read and Write access. This is required to list and read
-  comments for commands, and to create comments with the Plan output.
-* `Pull requests` with Read-Only access. This is required to check Pull Request
-  changes.
+* `Pull requests` with Read-Write access. This is required to check Pull Request
+  changes, list comments, and create or update comments.
 * `Metadata` with Read-only access. This is automatically marked as "mandatory"
   because of the permissions listed above.


### PR DESCRIPTION
The documentation said the token needs RW on Issues and R is enough on PullRequests, but in reality Issues are irrelevant, and RW is required for PullRequests.

Fixes #965

References:
* https://github.com/weaveworks/tf-controller/issues/965