### PR TITLE
fix: controller test 230

### DIFF
--- a/controllers/tc000230_drift_detection_only_mode_test.go
+++ b/controllers/tc000230_drift_detection_only_mode_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -50,7 +48,7 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -121,7 +119,7 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &testTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	testTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}


### PR DESCRIPTION
```
❯ go test ./controllers -parallel=1 -count=3 -test.run="Test_000230"
ok      github.com/weaveworks/tf-controller/controllers 41.527s
```

Fixes #948

References:
* https://github.com/weaveworks/tf-controller/issues/948