### PR TITLE
fix: controller test 24x

### DIFF
--- a/controllers/tc000240_health_check_test.go
+++ b/controllers/tc000240_health_check_test.go
@@ -30,7 +30,7 @@ func Test_000240_health_check_test(t *testing.T) {
 		},
 		{
 			name:    "testTCPInvalidPort",
-			address: "weave.works:81",
+			address: "localhost:81",
 			timeout: time.Second * 10,
 			wantErr: true,
 		},

--- a/controllers/tc000241_auto_approve_with_health_checks_test.go
+++ b/controllers/tc000241_auto_approve_with_health_checks_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -48,6 +46,7 @@ func Test_000241_auto_approve_with_health_checks_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	By("setting the git repo status object, the URL, and the correct checksum")
 	testRepo.Status = sourcev1.GitRepositoryStatus{
@@ -119,6 +118,7 @@ func Test_000241_auto_approve_with_health_checks_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &healthCheckTF)).Should(Succeed())
+	defer waitResourceToBeDelete(g, &healthCheckTF)
 
 	By("checking that the health check example TF gets created")
 	healthCheckTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}

--- a/controllers/tc000242_bad_health_checks_test.go
+++ b/controllers/tc000242_bad_health_checks_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -44,6 +42,7 @@ func Test_000242_bad_healt_checks_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	By("setting the git repo status object, the URL, and the correct checksum")
 	testRepo.Status = sourcev1.GitRepositoryStatus{
@@ -109,6 +108,7 @@ func Test_000242_bad_healt_checks_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &healthCheckTF)).Should(Succeed())
+	defer waitResourceToBeDelete(g, &healthCheckTF)
 
 	By("checking that the health check example TF gets created")
 	healthCheckTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}
@@ -174,6 +174,7 @@ func Test_000242_bad_healt_checks_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &healthCheckTF2)).Should(Succeed())
+	defer waitResourceToBeDelete(g, &healthCheckTF2)
 
 	By("checking that the health check example TF 2 gets created")
 	healthCheckTFKey2 := types.NamespacedName{Namespace: "flux-system", Name: terraformName}


### PR DESCRIPTION
```
❯ go test ./controllers -parallel=1 -count=3 -test.run="Test_00024"
ok      github.com/weaveworks/tf-controller/controllers 13.980s
```

I tried to remove all external calls from health check, but I couldn't because for 240, it said it can't parse `server.Addr()` as health check. For 241, it's hardcoded in the terraform file and the test server is dynamic.

It can still be flaky if it can't reach "weave.works" or the server rejects the request because of too many requests, or any other reasons.

For now, I think it's not an issue. If it will be, we have to spend some (a bit more) time on it, as it's not trivial to update those values.

Closes #949

References:
* https://github.com/weaveworks/tf-controller/issues/949