### PR TITLE
add set -e to the local e2e script

### DIFF
--- a/local-e2e.sh
+++ b/local-e2e.sh
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+# Exit the script if any command fails
+set -e
+
 VERSION=e2e-$(git rev-parse --short HEAD)-$(if [[ $(git diff --stat) != '' ]]; then echo 'dirty'; else echo 'clean'; fi)
 
 kind create cluster


### PR DESCRIPTION
A small fix that adds `set -e` to the local e2e script to fail fast.