### PR TITLE
correct the behaviour of e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -137,7 +137,16 @@ jobs:
       - name: Run drift detection tests
         run: |
           kubectl -n tf-system apply -f ./config/testdata/drift-detection
-          kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=ready=unknown --timeout=4m
+
+          # apply should be true first
+          kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
+
+          # patch .spec.approvePlan to "disable"
+          kubectl -n tf-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
+          kubectl -n tf-system wait  terraform/helloworld-drift-detection --for=condition=ready=true --timeout=4m
+
+          # disable drift detection
+          # the object should work correctly
           kubectl -n tf-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
 
           # delete after tests

--- a/config/testdata/drift-detection/test.yaml
+++ b/config/testdata/drift-detection/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helloworld-drift-detection
 spec:
   interval: 10s
-  approvePlan: "disable"
+  approvePlan: "auto" # first it must be auto, then use kubectl to patch this to "disable"
   path: ./
   sourceRef:
     kind: GitRepository

--- a/local-e2e.sh
+++ b/local-e2e.sh
@@ -62,7 +62,16 @@ kubectl -n tf-system delete -f ./config/testdata/always-clean-pod
 echo "==================== Run drift detection tests"
 
 kubectl -n tf-system apply -f ./config/testdata/drift-detection
-kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=ready=unknown --timeout=4m
+
+# apply should be true first
+kubectl -n tf-system wait terraform/helloworld-drift-detection --for=condition=apply=true --timeout=4m
+
+# patch .spec.approvePlan to "disable"
+kubectl -n tf-system patch terraform/helloworld-drift-detection -p '{"spec":{"approvePlan":"disable"}}' --type=merge
+kubectl -n tf-system wait  terraform/helloworld-drift-detection --for=condition=ready=true  --timeout=4m
+
+# disable drift detection
+# the object should work correctly
 kubectl -n tf-system wait terraform/helloworld-drift-detection-disable --for=condition=ready --timeout=4m
 
 # delete after tests


### PR DESCRIPTION
This change correct to behaviour of the drift e2e test case to:
- start with the auto mode and wait for the object applied state
- patch the object to be approvePlan: disable
- the object shoud continue to do drift detection correctly