### PR TITLE
tests: run non-numbered tests as part of the github workflow

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Setup Terraform
         run: |
           export TF_VERSION=1.3.9

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Setup Terraform
         run: |
           export TF_VERSION=1.3.7

--- a/.github/workflows/targeted-test.yaml
+++ b/.github/workflows/targeted-test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Setup Terraform
         run: |
           export TF_VERSION=1.3.9

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Setup Terraform
         run: |
           export TF_VERSION=1.3.9
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Setup Terraform
         run: |
           export TF_VERSION=1.3.9

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,34 +16,73 @@ on:
 
 jobs:
   test-1x-2x:
+    name: "Controller Tests: 10->29"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0000[12]"
   test-3x-5x:
+    name: "Controller Tests: 30->59"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0000[345]"
   test-6x-9x:
+    name: "Controller Tests: 60->99"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0000[6789]"
   test-1xx:
+    name: "Controller Tests: 1xx"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0001"
   test-2xx:
+    name: "Controller Tests: 2xx"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0002"
   test-3xx:
+    name: "Controller Tests: 3xx"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0003"
   test-99xx:
+    name: "Controller Tests: 99xx"
     uses: ./.github/workflows/targeted-test.yaml
     with:
       pattern: "^Test_0099"
+  non-numbered:
+    name: "Controller Tests: Non-numbered"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Go cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+      - name: Setup Terraform
+        run: |
+          export TF_VERSION=1.3.9
+          wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
+          unzip -q terraform_${TF_VERSION}_linux_amd64.zip
+          mv terraform $(which terraform)
+          terraform --version
+      - name: Setup Kustomize
+        if: "!github.event.pull_request.head.repo.fork"
+        uses: fluxcd/pkg/actions/kustomize@main
+      - name: Run tests
+        run: |
+          make install-envtest
+          make normal-controller-test
   internal:
+    name: "Internal Tests"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ test-flaky: manifests generate download-crd-deps fmt vet envtest api-docs ## Run
 target-test: manifests generate download-crd-deps fmt vet envtest api-docs ## Run tests. e.g make TARGET=250 target-test
 	$(TEST_SETTINGS) go test ./controllers -coverprofile cover.out -v -run $(TARGET)
 
+.PHONY: normal-controller-test
+normal-controller-test: manifests generate download-crd-deps fmt vet envtest api-docs ## Run non numbered controller tests.
+	$(TEST_SETTINGS) go test ./controllers -coverprofile cover.out -v -skip "Test_0"
+
 .PHONY: test-internal
 test-internal: manifests generate download-crd-deps fmt vet envtest api-docs ## Run tests in the internal directory.
 	$(TEST_SETTINGS) go test ./internal/... -coverprofile cover.out -v


### PR DESCRIPTION
Options I considered:
- Add a `testcase` build tag and use that to separate the two.
- Add skip option to the `target-test` target.
- Add create a new independent make target just to run those tests.

Dropped the idea to add build tag because ideally all of them should be easily executed locally without knowing you have to add `-tag testcase` to the command.

Dropped the skip option to `target-test` because that would make that way too complex, complex shell scripting in Makefiles can be fine, but I prefer not to do that. To create a separate shell script just for that, I didn't feel it's worth it.

At the end, I created a new `normal-controler-test` make target. The name is sketchy, but I couldn't come up with a better one, normal because it's not "test case based".

Fixes #981

References:
* https://github.com/weaveworks/tf-controller/issues/981