### PR TITLE
fix: controller test 20

### DIFF
--- a/controllers/tc000020_with_backend_no_outputs_test.go
+++ b/controllers/tc000020_with_backend_no_outputs_test.go
@@ -1,5 +1,3 @@
-//go:build flaky
-
 package controllers
 
 import (
@@ -51,7 +49,7 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -109,7 +107,7 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}
@@ -193,4 +191,5 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 		}
 		return tfStateSecret.Name
 	}, timeout, interval).Should(Equal("tfstate-default-" + terraformName))
+	defer waitResourceToBeDelete(g, &tfStateSecret)
 }

--- a/controllers/tc000020_with_workspace_no_outputs_test.go
+++ b/controllers/tc000020_with_workspace_no_outputs_test.go
@@ -49,7 +49,7 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	By("creating the GitRepository resource in the cluster.")
 	It("should be created successfully.")
 	g.Expect(k8sClient.Create(ctx, &testRepo)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &testRepo)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &testRepo)
 
 	Given("the GitRepository's reconciled status.")
 	By("setting the GitRepository's status, with the downloadable BLOB's URL, and the correct checksum.")
@@ -108,7 +108,7 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 	}
 	It("should be created and attached successfully.")
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer func() { g.Expect(k8sClient.Delete(ctx, &helloWorldTF)).Should(Succeed()) }()
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	By("checking that the TF resource existed inside the cluster.")
 	helloWorldTFKey := types.NamespacedName{Namespace: "flux-system", Name: terraformName}
@@ -192,4 +192,5 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 		}
 		return tfStateSecret.Name
 	}, timeout, interval).Should(Equal("tfstate-custom-" + terraformName))
+	defer waitResourceToBeDelete(g, &tfStateSecret)
 }


### PR DESCRIPTION
Somehow we missed this tone earlier.

```
❯ go test ./controllers -parallel=1 -count=3 -test.run="Test_000020"
ok      github.com/weaveworks/tf-controller/controllers 12.239s
```

Related to #865

References:
* https://github.com/weaveworks/tf-controller/issues/865