### PR TITLE
exclude branch from create object name function

### DIFF
--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -190,14 +190,14 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	// Ignore the first one as it's the original resource.
 	for idx, item := range tfList.Items[1:] {
-		expectToEqual(g, item.Name, fmt.Sprintf("%s-test-branch-%d-%d", original.Name, idx+1, idx+1))
-		expectToEqual(g, item.Spec.SourceRef.Name, fmt.Sprintf("%s-source-test-branch-%d-%d", original.Name, idx+1, idx+1))
+		expectToEqual(g, item.Name, fmt.Sprintf("%s-%d", original.Name, idx+1))
+		expectToEqual(g, item.Spec.SourceRef.Name, fmt.Sprintf("%s-source-%d", original.Name, idx+1))
 		expectToEqual(g, item.Spec.SourceRef.Namespace, ns.Name)
 		expectToEqual(g, item.Spec.PlanOnly, true)
 		expectToEqual(g, item.Spec.StoreReadablePlan, "human")
 		expectToEqual(g, item.Spec.ApprovePlan, "")
 		expectToEqual(g, item.Spec.Force, false)
-		expectToEqual(g, item.Spec.WriteOutputsToSecret.Name, fmt.Sprintf("test-secret-test-branch-%d-%d", idx+1, idx+1))
+		expectToEqual(g, item.Spec.WriteOutputsToSecret.Name, fmt.Sprintf("test-secret-%d", idx+1))
 		expectToEqual(g, item.Labels["infra.weave.works/branch-planner"], "true")
 		expectToEqual(g, item.Labels["test-label"], "abc")
 		expectToEqual(g, item.Labels["infra.weave.works/pr-id"], fmt.Sprint(idx+1))
@@ -215,7 +215,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	// Ignore the first one as it's the original resource.
 	for idx, item := range srcList.Items[1:] {
-		expectToEqual(g, item.Name, fmt.Sprintf("%s-test-branch-%d-%d", source.Name, idx+1, idx+1))
+		expectToEqual(g, item.Name, fmt.Sprintf("%s-%d", source.Name, idx+1))
 		expectToEqual(g, item.Spec.Reference.Branch, fmt.Sprintf("test-branch-%d", idx+1))
 		expectToEqual(g, item.Labels["infra.weave.works/branch-planner"], "true")
 		expectToEqual(g, item.Labels["test-label"], "123")
@@ -238,7 +238,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 	}))
 
 	for idx, item := range tfList.Items {
-		expectedSecretName := fmt.Sprintf("%s-test-branch-%d-%d", secretName, idx, idx)
+		expectedSecretName := fmt.Sprintf("%s-%d", secretName, idx)
 		if idx == 0 {
 			expectedSecretName = secretName
 		}
@@ -261,7 +261,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	expectToEqual(g, len(tfList.Items), 2)
 	expectToEqual(g, tfList.Items[0].Name, original.Name)
-	expectToEqual(g, tfList.Items[1].Name, original.Name+"-test-branch-3-3")
+	expectToEqual(g, tfList.Items[1].Name, original.Name+"-3")
 
 	srcList.Items = nil
 
@@ -271,7 +271,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	expectToEqual(g, len(srcList.Items), 2)
 	expectToEqual(g, srcList.Items[0].Name, source.Name)
-	expectToEqual(g, srcList.Items[1].Name, source.Name+"-test-branch-3-3")
+	expectToEqual(g, srcList.Items[1].Name, source.Name+"-3")
 
 	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -78,7 +78,7 @@ func (s *Server) getSource(ctx context.Context, tf *infrav1.Terraform) (*sourcev
 }
 
 func (s *Server) reconcileTerraform(ctx context.Context, originalTF *infrav1.Terraform, originalSource *sourcev1.GitRepository, branch string, prID string, interval time.Duration) error {
-	tfName := s.createObjectName(originalTF.Name, branch, prID)
+	tfName := s.createObjectName(originalTF.Name, prID)
 	msg := fmt.Sprintf("Terraform object %s in the namespace %s", tfName, originalTF.Namespace)
 	source, err := s.reconcileSource(ctx, originalSource, branch, prID, interval)
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *Server) reconcileTerraform(ctx context.Context, originalTF *infrav1.Ter
 
 		// Relocate the output secret, so it's not shared between branches
 		if spec.WriteOutputsToSecret != nil && originalTF.Spec.WriteOutputsToSecret != nil {
-			spec.WriteOutputsToSecret.Name = s.createObjectName(originalTF.Spec.WriteOutputsToSecret.Name, branch, prID)
+			spec.WriteOutputsToSecret.Name = s.createObjectName(originalTF.Spec.WriteOutputsToSecret.Name, prID)
 		}
 		spec.ApprovePlan = ""
 		spec.Force = false
@@ -131,7 +131,7 @@ func (s *Server) reconcileTerraform(ctx context.Context, originalTF *infrav1.Ter
 }
 
 func (s *Server) reconcileSource(ctx context.Context, originalSource *sourcev1.GitRepository, branch string, prID string, interval time.Duration) (*sourcev1.GitRepository, error) {
-	sourceName := s.createObjectName(originalSource.Name, branch, prID)
+	sourceName := s.createObjectName(originalSource.Name, prID)
 	msg := fmt.Sprintf("Source %s in the namespace %s", sourceName, originalSource.Namespace)
 	source := &sourcev1.GitRepository{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,8 +165,8 @@ func (s *Server) reconcileSource(ctx context.Context, originalSource *sourcev1.G
 	return source, nil
 }
 
-func (s *Server) createObjectName(name string, branch string, prID string) string {
-	return fmt.Sprintf("%s-%s-%s", name, branch, prID)
+func (s *Server) createObjectName(name string, prID string) string {
+	return fmt.Sprintf("%s-%s", name, prID)
 }
 
 func (s *Server) createLabels(labels map[string]string, originalName string, branch string, prID string) map[string]string {


### PR DESCRIPTION
Fixes #915

This PR excludes the branch name from the object name because:
1. A branch name is possible to contain slash (`/`) or underscore (`_`) which are invalid for a Kubernetes object name.
2. We already use PR ID as part of the identifier. PR number is sufficient to make the object name unique.