### PR TITLE
Add the `pr` string to suffix

### DIFF
--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -192,8 +192,8 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	// Ignore the first one as it's the original resource.
 	for idx, item := range tfList.Items[1:] {
-		expectToEqual(g, item.Name, fmt.Sprintf("%s-%d", original.Name, idx+1))
-		expectToEqual(g, item.Spec.SourceRef.Name, fmt.Sprintf("%s-source-%d", original.Name, idx+1))
+		expectToEqual(g, item.Name, fmt.Sprintf("%s-pr-%d", original.Name, idx+1))
+		expectToEqual(g, item.Spec.SourceRef.Name, fmt.Sprintf("%s-source-pr-%d", original.Name, idx+1))
 		expectToEqual(g, item.Spec.SourceRef.Namespace, ns.Name)
 		expectToEqual(g, item.Spec.PlanOnly, true)
 		expectToEqual(g, item.Spec.StoreReadablePlan, "human")
@@ -217,7 +217,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	// Ignore the first one as it's the original resource.
 	for idx, item := range srcList.Items[1:] {
-		expectToEqual(g, item.Name, fmt.Sprintf("%s-%d", source.Name, idx+1))
+		expectToEqual(g, item.Name, fmt.Sprintf("%s-pr-%d", source.Name, idx+1))
 		expectToEqual(g, item.Spec.Reference.Branch, fmt.Sprintf("test-branch-%d", idx+1))
 		expectToEqual(g, item.Labels[bpconfig.LabelKey], bpconfig.LabelValue)
 		expectToEqual(g, item.Labels["test-label"], "123")
@@ -260,7 +260,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	expectToEqual(g, len(tfList.Items), 2)
 	expectToEqual(g, tfList.Items[0].Name, original.Name)
-	expectToEqual(g, tfList.Items[1].Name, original.Name+"-3")
+	expectToEqual(g, tfList.Items[1].Name, original.Name+"-pr-3")
 
 	srcList.Items = nil
 
@@ -270,7 +270,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 
 	expectToEqual(g, len(srcList.Items), 2)
 	expectToEqual(g, srcList.Items[0].Name, source.Name)
-	expectToEqual(g, srcList.Items[1].Name, source.Name+"-3")
+	expectToEqual(g, srcList.Items[1].Name, source.Name+"-pr-3")
 
 	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -170,7 +170,7 @@ func (s *Server) reconcileSource(ctx context.Context, originalSource *sourcev1.G
 }
 
 func (s *Server) createObjectName(name string, prID string) string {
-	return fmt.Sprintf("%s-%s", name, prID)
+	return fmt.Sprintf("%s-pr-%s", name, prID)
 }
 
 func (s *Server) createLabels(labels map[string]string, originalName string, branch string, prID string) map[string]string {


### PR DESCRIPTION
A previous fix removed the branch name out of the object name, making
the object name harder to read. For example `hello-tf` became `hello-tf-1`.

This PR added the `pr` string to the suffix, resulting in the object
name `hello-tf-pr-1`. This makes it easier to discern that this object
corresponds to Pull Request 1 for example.

Fixes #1000 

Must merge after #1001