### PR TITLE
refactor: add testing.T to gomega wrapper functions

### DIFF
--- a/internal/informer/branch-planner/main_test.go
+++ b/internal/informer/branch-planner/main_test.go
@@ -63,7 +63,8 @@ var (
 // general, an individual test will want to create a namespace at its
 // start, use its name for any other objects it creates, and delete
 // the namespace afterward. Test_scaffold shows how to do this.
-func newNamespace(g gomega.Gomega) *corev1.Namespace {
+func newNamespace(t *testing.T, g gomega.Gomega) *corev1.Namespace {
+	t.Helper()
 	num := nscounter.Add(1)
 	name := fmt.Sprintf("test-ns-%d", num)
 	ns := corev1.Namespace{}
@@ -72,15 +73,16 @@ func newNamespace(g gomega.Gomega) *corev1.Namespace {
 	return &ns
 }
 
-func expectToSucceed(g gomega.Gomega, arg interface{}) {
+func expectToSucceed(t *testing.T, g gomega.Gomega, arg interface{}) {
+	t.Helper()
 	g.ExpectWithOffset(1, arg).To(gomega.Succeed())
 }
 
 // Minimal test to check the scaffolding works.
 func Test_scaffold(t *testing.T) {
 	g := gomega.NewWithT(t)
-	ns := newNamespace(g)
+	ns := newNamespace(t, g)
 	// here is where you'd create some objects in the namespace, as
 	// part of your test case.
-	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
+	t.Cleanup(func() { expectToSucceed(t, g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/main_test.go
+++ b/internal/server/polling/main_test.go
@@ -57,7 +57,7 @@ var (
 // general, an individual test will want to create a namespace at its
 // start, use its name for any other objects it creates, and delete
 // the namespace afterward. Test_scaffold shows how to do this.
-func newNamespace(g gomega.Gomega) *corev1.Namespace {
+func newNamespace(t *testing.T, g gomega.Gomega) *corev1.Namespace {
 	num := nscounter.Add(1)
 	name := fmt.Sprintf("test-ns-%d", num)
 	ns := corev1.Namespace{}
@@ -66,19 +66,19 @@ func newNamespace(g gomega.Gomega) *corev1.Namespace {
 	return &ns
 }
 
-func expectToSucceed(g gomega.Gomega, arg interface{}) {
+func expectToSucceed(t *testing.T, g gomega.Gomega, arg interface{}) {
 	g.ExpectWithOffset(1, arg).To(gomega.Succeed())
 }
 
-func expectToEqual(g gomega.Gomega, arg interface{}, expect interface{}, desc ...interface{}) {
+func expectToEqual(t *testing.T, g gomega.Gomega, arg interface{}, expect interface{}, desc ...interface{}) {
 	g.ExpectWithOffset(1, expect).To(gomega.Equal(arg), desc...)
 }
 
 // Minimal test to check the scaffolding works.
 func Test_scaffold(t *testing.T) {
 	g := gomega.NewWithT(t)
-	ns := newNamespace(g)
+	ns := newNamespace(t, g)
 	// here is where you'd create some objects in the namespace, as
 	// part of your test case.
-	t.Cleanup(func() { expectToSucceed(g, k8sClient.Delete(context.TODO(), ns)) })
+	t.Cleanup(func() { expectToSucceed(t, g, k8sClient.Delete(context.TODO(), ns)) })
 }


### PR DESCRIPTION
Gomega doesn't have a function to mark a function as a test helper function. The built-in `testing` package has a `t.Helper()` function that marks the function as a test helper and when it prints out where the error happened, it will skip that function.

These test helper functions were added when I asked to not use dot import (I still against using it). I don't think the wrapper functions make it much easier to write and read tests then aliasing the gomega module, but I was much happier with it then dot importing it. However it caused problems debugging failed test because the failed test reported back the issue is in `main_test.go:LINE`, which is not very helpful:

```
main_test.go:74:
  Expected
    <string>: true
  to equal
    <string>:
```

In my opinion we should just simply use `gom` alias (or anything, even the full `gomega` package name). Using the wrapper does not make it much shorter and if we don't have a wrapper for a specific assertion, people will just use an existing one instead of adding a new one.

```go
// Wrapper what we have now.
expectToEqual(t, g, len(srcList.Items), 1, "source list")

// Full package name.
g.Expect(len(srcList.Items)).ToBe(gomega.Equal(1), "source list")

// Alias version.
g.Expect(len(srcList.Items)).ToBe(gom.Equal(1), "source list")

// Even better as it's not forced to use Equal to to check slice length.
g.Expect(srcList.Items).ToBe(gom.HaveLen(1), "source list")
```