### PR TITLE
fix: branch planner does not use the original state file

### DIFF
--- a/internal/server/polling/main_test.go
+++ b/internal/server/polling/main_test.go
@@ -67,10 +67,12 @@ func newNamespace(t *testing.T, g gomega.Gomega) *corev1.Namespace {
 }
 
 func expectToSucceed(t *testing.T, g gomega.Gomega, arg interface{}) {
+	t.Helper()
 	g.ExpectWithOffset(1, arg).To(gomega.Succeed())
 }
 
 func expectToEqual(t *testing.T, g gomega.Gomega, arg interface{}, expect interface{}, desc ...interface{}) {
+	t.Helper()
 	g.ExpectWithOffset(1, expect).To(gomega.Equal(arg), desc...)
 }
 

--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -204,6 +204,8 @@ func Test_poll_reconcile_objects(t *testing.T) {
 		expectToEqual(t, g, item.Labels[bpconfig.LabelKey], bpconfig.LabelValue)
 		expectToEqual(t, g, item.Labels["test-label"], "abc")
 		expectToEqual(t, g, item.Labels[bpconfig.LabelPRIDKey], fmt.Sprint(idx+1))
+		expectToEqual(t, g, item.Spec.BackendConfig.SecretSuffix, original.Name)
+		expectToEqual(t, g, item.Spec.BackendConfig.InClusterConfig, true)
 	}
 
 	// Check that the Source objects are created with all expected fields.
@@ -313,6 +315,9 @@ func Test_poll_noPathChanges(t *testing.T) {
 			BranchPlanner: &infrav1.BranchPlanner{
 				EnablePathScope: true,
 			},
+			BackendConfig: &infrav1.BackendConfigSpec{
+				SecretSuffix: "special-value",
+			},
 		},
 	}
 	expectToSucceed(t, g, k8sClient.Create(context.TODO(), original))
@@ -360,6 +365,7 @@ func Test_poll_noPathChanges(t *testing.T) {
 	}))
 	expectToEqual(t, g, len(tfList.Items), 1, "terraform list") // just the original
 	expectToEqual(t, g, tfList.Items[0].Name, original.Name)
+	expectToEqual(t, g, tfList.Items[0].Spec.BackendConfig, original.Spec.BackendConfig)
 
 	var srcList sourcev1.GitRepositoryList
 	expectToSucceed(t, g, k8sClient.List(context.TODO(), &srcList, &client.ListOptions{

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -119,6 +119,13 @@ func (s *Server) reconcileTerraform(ctx context.Context, originalTF *infrav1.Ter
 			spec.CliConfigSecretRef = nil
 		}
 
+		if spec.BackendConfig == nil {
+			spec.BackendConfig = &infrav1.BackendConfigSpec{
+				SecretSuffix:    originalTF.Name,
+				InClusterConfig: true,
+			}
+		}
+
 		tf.Spec = *spec
 
 		tf.SetLabels(branchLabels)


### PR DESCRIPTION
By default the `SecretSuffix` is set to the name of the Terraform
resource, because of this, if it's not set on the original Terraform
resource, it's not set on the cloned one with Branch Planner. As a
result, the Branch Planner resource uses a separate state file.

This small patch makes sure the cloned object uses the same statefile
secret.

Fixes #1021

References:
* https://github.com/weaveworks/tf-controller/issues/1021