### PR TITLE
Vars overriden by VarsFrom

### DIFF
--- a/controllers/tc000090_varsfrom_override_and_controlled_outputs_test.go
+++ b/controllers/tc000090_varsfrom_override_and_controlled_outputs_test.go
@@ -151,7 +151,7 @@ func Test_000090_varsfrom_override_and_controlled_outputs_test(t *testing.T) {
 	expectedOutputValue := map[string]string{
 		"Name":        "tf-output-" + terraformName,
 		"Namespace":   "flux-system",
-		"Value":       "Hello, my overridden cat!",
+		"Value":       "Hello, my cat!",
 		"OwnerRef[0]": string(createdHelloWorldTF.UID),
 	}
 	g.Eventually(func() (map[string]string, error) {

--- a/docs/use_tf_controller/to_set_variables_for_Terraform_resources.md
+++ b/docs/use_tf_controller/to_set_variables_for_Terraform_resources.md
@@ -27,8 +27,9 @@ Inline variables can be set using `vars`. The `varsFrom` field accepts a list of
 You may use the `varsKeys` property of `varsFrom` to select specific keys from the input or omit this field
 to select all keys from the input source.
 
-Note that in the case of the same variable key being passed multiple times, the controller will use
-the lattermost instance of the key passed to `varsFrom`.
+Values from `varsFrom` are always read first and then values from `vars` are read. If the same key is used in `varsFrom`
+as in `vars`, the value from `varsFrom` will be overwritten. This mechanism allows us to have the global variables set 
+once in one of the ConfigMaps or Secrets, and if necessary we can overwrite the value directly in the Terraform object.
 
 ```yaml hl_lines="15-20 22-28"
 apiVersion: infra.contrib.fluxcd.io/v1alpha2

--- a/runner/server_generate_tf_vars.go
+++ b/runner/server_generate_tf_vars.go
@@ -243,13 +243,6 @@ func (r *TerraformRunnerServer) GenerateVarsForTF(ctx context.Context, req *Gene
 		vars["values"] = &apiextensionsv1.JSON{Raw: buf.Bytes()}
 	}
 
-	log.Info("mapping the Spec.Vars")
-	if len(terraform.Spec.Vars) > 0 {
-		for _, v := range terraform.Spec.Vars {
-			vars[v.Name] = v.Value
-		}
-	}
-
 	log.Info("mapping the Spec.VarsFrom")
 	// varsFrom overwrite vars
 	for _, vf := range terraform.Spec.VarsFrom {
@@ -341,6 +334,13 @@ func (r *TerraformRunnerServer) GenerateVarsForTF(ctx context.Context, req *Gene
 					}
 				}
 			}
+		}
+	}
+
+	log.Info("mapping the Spec.Vars")
+	if len(terraform.Spec.Vars) > 0 {
+		for _, v := range terraform.Spec.Vars {
+			vars[v.Name] = v.Value
 		}
 	}
 


### PR DESCRIPTION
Fixes #634 

_I apologize for accidentally closing the [previous PR](https://github.com/weaveworks/tf-controller/pull/1093) I did `git reset -hard <start commit> and git push -f` on my fork which automatically closed the upstream PR.  It behaved a bit differently than I expected._ 

---
The purpose of this change is to enable overriding variables mechanism. I want to define default values (specified in `varsFrom` via configMap or Secret) and customize them via `vars`.

All I do is just change the order of writing to the variables + update overriding in 090xxx test.

Example:
create a configMap named `defaults-cm` with the value `costCenter=123456` and add it to all Terraform manifests.
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: default-cm
data:
  costCenter: 123456
```

Everything that tf-runner will run will have the default variable `costCenter=123456`, because all Terraform Manifests have the field:
```yaml
spec:
  varsFrom:
    - kind: configMap
      name: defaults-cm
```

A request is received that the part of the infrastructure that is specified by the Terraform  manifest named `override` has `costCenter=888888`. I can do this easily, because I override the value via vars:

```yaml
kind: Terraform
Metadata:
  name: override
spec:
  vars:
  - name: costCenter
    value: 88888
```

Thanks to particular Terraform.Spec.Vars I can override globaly defined variables specified in Terraform.Spec.VarsFrom and easily customize the entire infrastructure.
