### PR TITLE
Fix break glass command; respect all flags

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,16 +18,19 @@ to merge them for you after reviews.
 
 ## Protobuf Setup
 
-TF-controller requires a specific version of Protobuf compiler and its Go plugins. 
+TF-controller requires a specific version of Protobuf compiler and its Go plugins.
 
 * Protoc: version [3.19.4](https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip)
 * Go plugin: `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1`
 * Go plugin: `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`
 
+These can be installed by running `make tools`.
+
 ## How to run the test suite
 
 Prerequisites:
-* go = 1.19.x
+
+* go = 1.20.x
 * kubebuilder = 3.6.x
 * controller-gen = 0.8.x
 * kustomize = 4.x
@@ -44,6 +47,7 @@ If you get an error stating "etcd" not found then run:
 ```bash
 make install-envtest
 ```
+
 and then retry `make test`
 
 ## GRPC
@@ -63,6 +67,7 @@ make gen-grpc
 ```
 
 to update the the generated `runner.pg.go` data.
+
 ## How to run the controller locally
 
 Install flux on your test cluster:
@@ -127,7 +132,6 @@ make docker-push
 
 **Note**: `make docker-build` will build an image for the `amd64` architecture.
 
-
 ### Deploying into a cluster
 
 Deploy `tf-controller` into the cluster that is configured in the local kubeconfig file (i.e. `~/.kube/config`):
@@ -152,15 +156,15 @@ To discuss ideas and specifications we use [Github Discussions](https://github.c
 
 These things will make a PR more likely to be accepted:
 
-- a well-described requirement
-- tests for new code
-- tests for old code!
-- new code and tests follow the conventions in old code and tests
-- a good commit message (see below)
-- all code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
-- names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
-- code must build on both Linux and Darwin, via plain `go build`
-- code should have appropriate test coverage and tests should be written
+* a well-described requirement
+* tests for new code
+* tests for old code!
+* new code and tests follow the conventions in old code and tests
+* a good commit message (see below)
+* all code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+* names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
+* code must build on both Linux and Darwin, via plain `go build`
+* code should have appropriate test coverage and tests should be written
   to work with `go test`
 
 In general, we will merge a PR once one maintainer has endorsed it.
@@ -171,9 +175,9 @@ get asked to resubmit the PR or divide the changes into more than one PR.
 
 We prefer the following rules for good commit messages:
 
-- Limit the subject to 50 characters and write as the continuation
+* Limit the subject to 50 characters and write as the continuation
   of the sentence "If applied, this commit will ..."
-- Explain what and why in the body, if more than a trivial change;
+* Explain what and why in the body, if more than a trivial change;
   wrap it at 72 characters.
 
 The [following article](https://chris.beams.io/posts/git-commit/#seven-rules)

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ build: gen-grpc generate fmt vet ## Build manager binary.
 install-cli:
 	go build -o ${GOPATH}/bin/tfctl \
 		-ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" \
-		cmd/tfctl/main.go
+		./cmd/tfctl
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/cmd/tfctl/main.go
+++ b/cmd/tfctl/main.go
@@ -37,11 +37,7 @@ func newRootCommand() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			k8sConfig, err := kubeconfigArgs.ToRESTConfig()
-			if err != nil {
-				return err
-			}
-			return app.Init(k8sConfig, config)
+			return app.Init(kubeconfigArgs, config)
 		},
 	}
 

--- a/tfctl/break_glass.go
+++ b/tfctl/break_glass.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
@@ -112,16 +113,63 @@ func shell(ctx context.Context, kubeconfigArgs *genericclioptions.ConfigFlags, t
 	cmdArgs := []string{"exec", "--stdin", "--tty"}
 
 	// add Namespace
-	cmdArgs = append(cmdArgs, "-n", namespace)
+	cmdArgs = append(cmdArgs, "--namespace", namespace)
+
+	// add Username if set
+	if kubeconfigArgs.Username != nil {
+		cmdArgs = append(cmdArgs, "--as", *kubeconfigArgs.Username)
+	}
+
+	// add ImpersonateGroup(s) if set
+	if kubeconfigArgs.ImpersonateGroup != nil {
+		for _, group := range *kubeconfigArgs.ImpersonateGroup {
+			cmdArgs = append(cmdArgs, "--as-group", group)
+		}
+	}
+
+	// add ImpersonateUID if set
+	if kubeconfigArgs.ImpersonateUID != nil {
+		cmdArgs = append(cmdArgs, "--as-uid", *kubeconfigArgs.ImpersonateUID)
+	}
+
+	// add CacheDir if set
+	if kubeconfigArgs.CacheDir != nil {
+		cmdArgs = append(cmdArgs, "--cache-dir", *kubeconfigArgs.CacheDir)
+	}
+
+	// add CAFile if set
+	if kubeconfigArgs.CAFile != nil {
+		cmdArgs = append(cmdArgs, "--certificate-authority", *kubeconfigArgs.CAFile)
+	}
+
+	// add CertFile if set
+	if kubeconfigArgs.CertFile != nil {
+		cmdArgs = append(cmdArgs, "--client-certificate", *kubeconfigArgs.CertFile)
+	}
+
+	// add KeyFile if set
+	if kubeconfigArgs.KeyFile != nil {
+		cmdArgs = append(cmdArgs, "--client-key", *kubeconfigArgs.KeyFile)
+	}
+
+	// add ClusterName if set
+	if kubeconfigArgs.ClusterName != nil {
+		cmdArgs = append(cmdArgs, "--cluster", *kubeconfigArgs.ClusterName)
+	}
 
 	// add Context if set
 	if kubeconfigArgs.Context != nil {
 		cmdArgs = append(cmdArgs, "--context", *kubeconfigArgs.Context)
 	}
 
-	// add Cluster Name if set
-	if kubeconfigArgs.ClusterName != nil {
-		cmdArgs = append(cmdArgs, "--cluster", *kubeconfigArgs.ClusterName)
+	// add DisableCompression if set
+	if kubeconfigArgs.DisableCompression != nil {
+		cmdArgs = append(cmdArgs, "--disable-compression", strconv.FormatBool(*kubeconfigArgs.DisableCompression))
+	}
+
+	// add Insecure if set
+	if kubeconfigArgs.Insecure != nil {
+		cmdArgs = append(cmdArgs, "--insecure-skip-tls-verify", strconv.FormatBool(*kubeconfigArgs.Insecure))
 	}
 
 	// add Kubeconfig file if set
@@ -129,9 +177,29 @@ func shell(ctx context.Context, kubeconfigArgs *genericclioptions.ConfigFlags, t
 		cmdArgs = append(cmdArgs, "--kubeconfig", *kubeconfigArgs.KubeConfig)
 	}
 
+	// add Timeout if set
+	if kubeconfigArgs.Timeout != nil {
+		cmdArgs = append(cmdArgs, "--request-timeout", *kubeconfigArgs.Timeout)
+	}
+
 	// add APIServer if set
 	if kubeconfigArgs.APIServer != nil {
 		cmdArgs = append(cmdArgs, "--server", *kubeconfigArgs.APIServer)
+	}
+
+	// add TLSServerName if set
+	if kubeconfigArgs.TLSServerName != nil {
+		cmdArgs = append(cmdArgs, "--tls-server-name", *kubeconfigArgs.TLSServerName)
+	}
+
+	// add BearerToken if set
+	if kubeconfigArgs.BearerToken != nil {
+		cmdArgs = append(cmdArgs, "--token", *kubeconfigArgs.BearerToken)
+	}
+
+	// add AuthInfoName if set
+	if kubeconfigArgs.AuthInfoName != nil {
+		cmdArgs = append(cmdArgs, "--user", *kubeconfigArgs.AuthInfoName)
 	}
 
 	// add podName of the runner

--- a/tfctl/break_glass.go
+++ b/tfctl/break_glass.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"time"
 
 	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
@@ -116,89 +115,89 @@ func shell(ctx context.Context, kubeconfigArgs *genericclioptions.ConfigFlags, t
 	cmdArgs = append(cmdArgs, "--namespace", namespace)
 
 	// add Username if set
-	if kubeconfigArgs.Username != nil {
+	if kubeconfigArgs.Username != nil && *kubeconfigArgs.Username != "" {
 		cmdArgs = append(cmdArgs, "--as", *kubeconfigArgs.Username)
 	}
 
 	// add ImpersonateGroup(s) if set
-	if kubeconfigArgs.ImpersonateGroup != nil {
+	if kubeconfigArgs.ImpersonateGroup != nil && len(*kubeconfigArgs.ImpersonateGroup) != 0 {
 		for _, group := range *kubeconfigArgs.ImpersonateGroup {
 			cmdArgs = append(cmdArgs, "--as-group", group)
 		}
 	}
 
 	// add ImpersonateUID if set
-	if kubeconfigArgs.ImpersonateUID != nil {
+	if kubeconfigArgs.ImpersonateUID != nil && *kubeconfigArgs.ImpersonateUID != "" {
 		cmdArgs = append(cmdArgs, "--as-uid", *kubeconfigArgs.ImpersonateUID)
 	}
 
 	// add CacheDir if set
-	if kubeconfigArgs.CacheDir != nil {
+	if kubeconfigArgs.CacheDir != nil && *kubeconfigArgs.CacheDir != "" {
 		cmdArgs = append(cmdArgs, "--cache-dir", *kubeconfigArgs.CacheDir)
 	}
 
 	// add CAFile if set
-	if kubeconfigArgs.CAFile != nil {
+	if kubeconfigArgs.CAFile != nil && *kubeconfigArgs.CAFile != "" {
 		cmdArgs = append(cmdArgs, "--certificate-authority", *kubeconfigArgs.CAFile)
 	}
 
 	// add CertFile if set
-	if kubeconfigArgs.CertFile != nil {
+	if kubeconfigArgs.CertFile != nil && *kubeconfigArgs.CertFile != "" {
 		cmdArgs = append(cmdArgs, "--client-certificate", *kubeconfigArgs.CertFile)
 	}
 
 	// add KeyFile if set
-	if kubeconfigArgs.KeyFile != nil {
+	if kubeconfigArgs.KeyFile != nil && *kubeconfigArgs.KeyFile != "" {
 		cmdArgs = append(cmdArgs, "--client-key", *kubeconfigArgs.KeyFile)
 	}
 
 	// add ClusterName if set
-	if kubeconfigArgs.ClusterName != nil {
+	if kubeconfigArgs.ClusterName != nil && *kubeconfigArgs.ClusterName != "" {
 		cmdArgs = append(cmdArgs, "--cluster", *kubeconfigArgs.ClusterName)
 	}
 
 	// add Context if set
-	if kubeconfigArgs.Context != nil {
+	if kubeconfigArgs.Context != nil && *kubeconfigArgs.Context != "" {
 		cmdArgs = append(cmdArgs, "--context", *kubeconfigArgs.Context)
 	}
 
 	// add DisableCompression if set
-	if kubeconfigArgs.DisableCompression != nil {
-		cmdArgs = append(cmdArgs, "--disable-compression", strconv.FormatBool(*kubeconfigArgs.DisableCompression))
+	if kubeconfigArgs.DisableCompression != nil && *kubeconfigArgs.DisableCompression {
+		cmdArgs = append(cmdArgs, "--disable-compression")
 	}
 
 	// add Insecure if set
-	if kubeconfigArgs.Insecure != nil {
-		cmdArgs = append(cmdArgs, "--insecure-skip-tls-verify", strconv.FormatBool(*kubeconfigArgs.Insecure))
+	if kubeconfigArgs.Insecure != nil && *kubeconfigArgs.Insecure {
+		cmdArgs = append(cmdArgs, "--insecure-skip-tls-verify")
 	}
 
 	// add Kubeconfig file if set
-	if kubeconfigArgs.KubeConfig != nil {
+	if kubeconfigArgs.KubeConfig != nil && *kubeconfigArgs.KubeConfig != "" {
 		cmdArgs = append(cmdArgs, "--kubeconfig", *kubeconfigArgs.KubeConfig)
 	}
 
 	// add Timeout if set
-	if kubeconfigArgs.Timeout != nil {
+	if kubeconfigArgs.Timeout != nil && *kubeconfigArgs.Timeout != "" {
 		cmdArgs = append(cmdArgs, "--request-timeout", *kubeconfigArgs.Timeout)
 	}
 
 	// add APIServer if set
-	if kubeconfigArgs.APIServer != nil {
+	if kubeconfigArgs.APIServer != nil && *kubeconfigArgs.APIServer != "" {
 		cmdArgs = append(cmdArgs, "--server", *kubeconfigArgs.APIServer)
 	}
 
 	// add TLSServerName if set
-	if kubeconfigArgs.TLSServerName != nil {
+	if kubeconfigArgs.TLSServerName != nil && *kubeconfigArgs.TLSServerName != "" {
 		cmdArgs = append(cmdArgs, "--tls-server-name", *kubeconfigArgs.TLSServerName)
 	}
 
 	// add BearerToken if set
-	if kubeconfigArgs.BearerToken != nil {
+	if kubeconfigArgs.BearerToken != nil && *kubeconfigArgs.BearerToken != "" {
 		cmdArgs = append(cmdArgs, "--token", *kubeconfigArgs.BearerToken)
 	}
 
 	// add AuthInfoName if set
-	if kubeconfigArgs.AuthInfoName != nil {
+	if kubeconfigArgs.AuthInfoName != nil && *kubeconfigArgs.AuthInfoName != "" {
 		cmdArgs = append(cmdArgs, "--user", *kubeconfigArgs.AuthInfoName)
 	}
 


### PR DESCRIPTION
fixes #1097

As I said in #1097, break-glass could easily target the wrong cluster. This happened to me.
This PR adds the flags to the command, that should be passed and can be passed according to `tfctl help`.

Please try to get it into 0.16.0, so the fix gets out fast.