### PR TITLE
test: add test around the polling server and fix surfaced issues

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -103,3 +103,14 @@ func Test_ReadConfig_resources(t *testing.T) {
 	g.Expect(conf.Resources[2].Name).To(gomega.Equal(""))
 	g.Expect(conf.Resources[2].Namespace).To(gomega.Equal("myns"))
 }
+
+func Test_RuntimeNamespace(t *testing.T) {
+	g := gomega.NewWithT(t)
+	runtimeNamespace := "runtime-namespace"
+
+	os.Setenv("RUNTIME_NAMESPACE", runtimeNamespace)
+	g.Expect(config.RuntimeNamespace(), runtimeNamespace)
+
+	os.Unsetenv("RUNTIME_NAMESPACE")
+	g.Expect(config.RuntimeNamespace(), config.DefaultNamespace)
+}

--- a/internal/git/provider/provider.go
+++ b/internal/git/provider/provider.go
@@ -19,6 +19,8 @@ const (
 	ProviderAzure     = ProviderType(giturlapis.ProviderAzure)
 )
 
+type URLParserFn = func(repoURL string, options ...ProviderOption) (Provider, Repository, error)
+
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Provider
 
 type Provider interface {

--- a/internal/server/polling/fake_git_provider_test.go
+++ b/internal/server/polling/fake_git_provider_test.go
@@ -1,0 +1,24 @@
+package polling_test
+
+import (
+	"fmt"
+
+	giturl "github.com/kubescape/go-git-url"
+	"github.com/weaveworks/tf-controller/internal/git/provider"
+)
+
+func mockedProvider(gitProvider provider.Provider) provider.URLParserFn {
+	return func(repoURL string, options ...provider.ProviderOption) (provider.Provider, provider.Repository, error) {
+		gitURL, err := giturl.NewGitURL(repoURL)
+		if err != nil {
+			return nil, provider.Repository{}, fmt.Errorf("failed parsing repository url: %w", err)
+		}
+
+		repo := provider.Repository{
+			Org:  gitURL.GetOwnerName(),
+			Name: gitURL.GetRepoName(),
+		}
+
+		return gitProvider, repo, nil
+	}
+}

--- a/internal/server/polling/option.go
+++ b/internal/server/polling/option.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/weaveworks/tf-controller/internal/config"
+	"github.com/weaveworks/tf-controller/internal/git/provider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -69,6 +70,14 @@ func WithNoCrossNamespaceRefs(deny bool) Option {
 func WithAllowedNamespaces(namespaces []string) Option {
 	return func(s *Server) error {
 		s.allowedNamespaces = namespaces
+		return nil
+	}
+}
+
+func WithCustomProviderURLParserFn(fn provider.URLParserFn) Option {
+	return func(s *Server) error {
+		s.gitProviderParserFn = fn
+
 		return nil
 	}
 }

--- a/internal/server/polling/server_test.go
+++ b/internal/server/polling/server_test.go
@@ -1,0 +1,167 @@
+package polling_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/logger"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/onsi/gomega"
+	infrav1 "github.com/weaveworks/tf-controller/api/v1alpha2"
+	"github.com/weaveworks/tf-controller/internal/config"
+	"github.com/weaveworks/tf-controller/internal/git/provider"
+	"github.com/weaveworks/tf-controller/internal/git/provider/providerfakes"
+	"github.com/weaveworks/tf-controller/internal/server/polling"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	logLevel           = "error"
+	eventuallyTimeout  = time.Second * 30
+	eventuallyInterval = time.Millisecond * 500
+)
+
+func Test_Server(t *testing.T) {
+	g := gomega.NewWithT(t)
+	objects := testResources(config.DefaultNamespace)
+	fakeClient := fake.NewClientBuilder().WithObjects(objects...).WithStatusSubresource(objects...).Build()
+	log := logger.NewLogger(logger.Options{LogLevel: logLevel}).WithName("informer")
+
+	fakePRConf := struct{ closed bool }{closed: false}
+	fakeComments := []*provider.Comment{}
+
+	fakeProvider := providerfakes.FakeProvider{
+		ListPullRequestsStub: func(ctx context.Context, repo provider.Repository) ([]provider.PullRequest, error) {
+			return []provider.PullRequest{
+				{
+					Repository: repo,
+					Number:     1,
+					BaseBranch: "main",
+					HeadBranch: "patch-1",
+					BaseSha:    "2861800e346d71bf74eac623387e1b2b507ef4af",
+					HeadSha:    "ae22c1b3dad69da20a4a02cd090ac9f6183babea",
+					Closed:     fakePRConf.closed,
+				},
+			}, nil
+		},
+		GetLastCommentsStub: func(context.Context, provider.PullRequest, time.Time) ([]*provider.Comment, error) {
+			return fakeComments, nil
+		},
+		AddCommentToPullRequestStub: func(context.Context, provider.PullRequest, []byte) (*provider.Comment, error) {
+			return &provider.Comment{
+				ID: 2,
+			}, nil
+		},
+	}
+
+	server, err := polling.New(
+		polling.WithClusterClient(fakeClient),
+		polling.WithBranchPollingInterval(time.Second),
+		polling.WithPollingInterval(time.Second),
+		polling.WithCustomProviderURLParserFn(mockedProvider(&fakeProvider)),
+		polling.WithLogger(log),
+	)
+	g.Expect(err).To(gomega.Succeed())
+
+	serverDone := make(chan bool)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		server.Start(ctx)
+		serverDone <- true
+	}()
+
+	prtf := &infrav1.Terraform{}
+	prtfKey := client.ObjectKey{Name: "tf1-pr-1", Namespace: config.DefaultNamespace}
+
+	t.Log("A new branch planner Terraform resource should be created.")
+	g.Eventually(func() error {
+		return fakeClient.Get(ctx, prtfKey, prtf)
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+
+	g.Expect(fakeProvider.ListPullRequestsCallCount()).To(gomega.BeNumerically(">", 0))
+
+	t.Log("When the Pull Request has a new comment with !replan, a replan request should be sent")
+	fakeComments = append(fakeComments, &provider.Comment{
+		ID:   123,
+		Link: "",
+		Body: "!replan",
+	})
+	oldReconcileRequestAnnotation := ""
+	if prtf.Annotations != nil {
+		oldReconcileRequestAnnotation = prtf.Annotations[meta.ReconcileRequestAnnotation]
+	}
+	g.Eventually(func() error {
+		if err := fakeClient.Get(ctx, prtfKey, prtf); err != nil {
+			return nil
+		}
+		if prtf.Annotations == nil {
+			return fmt.Errorf("resource has no annotations")
+		}
+		if prtf.Annotations[config.AnnotationCommentIDKey] != "2" {
+			return fmt.Errorf("%q is not up to date: %s", config.AnnotationCommentIDKey, prtf.Annotations[config.AnnotationCommentIDKey])
+		}
+		if prtf.Annotations[meta.ReconcileRequestAnnotation] == oldReconcileRequestAnnotation {
+			return fmt.Errorf("annotation %q is not up to date: %s", meta.ReconcileRequestAnnotation, prtf.Annotations[meta.ReconcileRequestAnnotation])
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+
+	t.Log("As we close the Pull Request, the branch planner Terraform resource should be deleted.")
+	fakePRConf.closed = true
+
+	g.Eventually(func() error {
+		return fakeClient.Get(ctx, prtfKey, prtf)
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.Succeed())
+
+	cancel()
+	<-serverDone
+}
+
+func testResources(namespace string) []client.Object {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-planner-config",
+			Namespace: namespace,
+		},
+		Data: map[string]string{},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-planner-token",
+			Namespace: namespace,
+		},
+	}
+	source := &sourcev1.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tf1",
+			Namespace: namespace,
+		},
+		Spec: sourcev1.GitRepositorySpec{
+			URL: "https://github.com/weaveworks/tf-conrtoller",
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "main",
+			},
+		},
+	}
+	terraform := &infrav1.Terraform{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tf1",
+			Namespace: namespace,
+		},
+		Spec: infrav1.TerraformSpec{
+			SourceRef: infrav1.CrossNamespaceSourceReference{
+				Kind:      sourcev1.GitRepositoryKind,
+				Name:      source.GetName(),
+				Namespace: source.GetNamespace(),
+			},
+		},
+	}
+	return []client.Object{configMap, secret, source, terraform}
+}

--- a/internal/server/polling/terraform.go
+++ b/internal/server/polling/terraform.go
@@ -158,7 +158,11 @@ func (s *Server) reconcileSource(ctx context.Context, originalSource *sourcev1.G
 
 		spec := originalSource.Spec.DeepCopy()
 
-		spec.Reference.Branch = branch
+		if spec.Reference != nil {
+			spec.Reference.Branch = branch
+		} else {
+			spec.Reference = &sourcev1.GitRepositoryRef{Branch: branch}
+		}
 		spec.Interval = metav1.Duration{
 			Duration: interval,
 		}


### PR DESCRIPTION
The test is very simple for now:
1. Creates some basic test resources.
2. Uses a fake k8s client.
3. Uses a fake git provider.
4. Starts the polling server.
5. Waits until the branch planner resource appears.
6. Creates a replan comment.
7. Waits until the branch planner resource has "reconcile" request
   and placeholder comment id annotation.
8. Marks the pull request as closed.
9. Waits until the branch planner resource is deleted.

That covers the basic logic.

Discovered issues:
1. The isAllowedNamespace check was wrong.
2. The Source object can have nil Reference for branch.
   I don't know what it does, I assume it uses a default branch, but we
   didn't handle that.

Other changes:
1. I moved the `provider.FromURL` into a Server struct level field so we
   can mock the provider layer. I tried to come up other ideas, but that
   looked the less messy.

Closes #837

References:
* https://github.com/weaveworks/tf-controller/issues/837