### PR TITLE
docs: Bump version in manifest used in user guide to reflect latest RC

### DIFF
--- a/docs/rc.yaml
+++ b/docs/rc.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: tf-controller
-      version: '>=0.15.0-rc.6'
+      version: '>=0.16.0-rc.3'
   interval: 1h0s
   releaseName: tf-controller
   targetNamespace: flux-system
@@ -42,7 +42,7 @@ spec:
     caCertValidityDuration: 24h
     certRotationCheckFrequency: 30m
     image:
-      tag: v0.15.0-rc.6
+      tag: v0.16.0-rc.3
     runner:
       image:
-        tag: v0.15.0-rc.6
+        tag: v0.16.0-rc.3


### PR DESCRIPTION
Fixes [rc.yaml](https://raw.githubusercontent.com/weaveworks/tf-controller/main/docs/rc.yaml) to point to latest RC.