### PR TITLE
chore(scripting): a simple script to bump libcrypto3 and libssl3 version

### DIFF
--- a/tools/bump-libcrypto3-libssl3.sh
+++ b/tools/bump-libcrypto3-libssl3.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+files=(
+  Makefile
+  Tiltfile
+  .github/workflows/release-runners.yaml
+  .github/workflows/release.yaml
+  .github/workflows/build-and-publish.yaml
+)
+
+old=$(grep "LIBCRYPTO_VERSION ?= " Makefile | cut -d ' ' -f 3)
+new=${1:-}
+
+
+if [ "${old}" == "" -o "${new}" == "" ]; then
+  echo "$0 <new version>"
+  exit 1
+fi
+
+echo " --> Old version: ${old}"
+echo " --> New version: ${new}"
+
+echo ""
+echo "Press ^C to exit or any key to continue..."
+read
+
+for f in "${files[@]}"; do
+  sed -i "s/${old}/${new}/g" "${f}"
+done


### PR DESCRIPTION
Simple usage:

```
❯ ./tools/bump-libcrypto3-libssl3.sh 3.1.4-r1
 --> Old version: 3.1.4-r0
 --> New version: 3.1.4-r1

Press ^C to exit or any key to continue...
```