### PR TITLE
fix: add unique hash to cloned source to avoid conflict

### DIFF
--- a/internal/config/naming.go
+++ b/internal/config/naming.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+func GenerateUniqueHash(components ...string) string {
+	name := strings.Join(components, "-")
+	hash := sha256.New()
+	hash.Write([]byte(name))
+	sum := hash.Sum(nil)
+
+	// Use only the first 10 bytes to avoid long names.
+	// It can still collide, but less likely.
+	return fmt.Sprintf("%x", sum[:10])
+}
+
+func PullRequestObjectName(name, prID string) string {
+	return fmt.Sprintf("%s-pr-%s", name, prID)
+}
+
+func SourceName(tfName, sourceName, prID string) string {
+	uniqueName := fmt.Sprintf("%s-%s", sourceName, GenerateUniqueHash(tfName, sourceName, prID))
+
+	return PullRequestObjectName(uniqueName, prID)
+}

--- a/internal/config/naming_test.go
+++ b/internal/config/naming_test.go
@@ -1,0 +1,22 @@
+package config_test
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+	"github.com/weaveworks/tf-controller/internal/config"
+)
+
+func Test_PullRequestObjectName(t *testing.T) {
+	g := gm.NewWithT(t)
+	g.Expect(config.PullRequestObjectName("fancy-tf", "123")).
+		To(gm.Equal("fancy-tf-pr-123"))
+}
+
+func Test_SourceName(t *testing.T) {
+	g := gm.NewWithT(t)
+	g.Expect(config.SourceName("fancy-tf", "fancy-source", "123")).
+		To(gm.Equal("fancy-source-3ec173d658529c0e7327-pr-123"))
+	g.Expect(config.SourceName("fancy-tf", "fancy-source", "124")).
+		To(gm.Equal("fancy-source-1933cdc683fdc86fb62e-pr-124"))
+}

--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -2,9 +2,9 @@ package polling
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
+	"github.com/weaveworks/tf-controller/internal/config"
 	bpconfig "github.com/weaveworks/tf-controller/internal/config"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -188,13 +188,14 @@ func Test_poll_reconcile_objects(t *testing.T) {
 	}))
 
 	expectToEqual(t, g, len(tfList.Items), 4)
-	// The first one is the original Terraform object.
-	expectToEqual(t, g, tfList.Items[0].Name, original.Name)
-
-	// Ignore the first one as it's the original resource.
-	for idx, item := range tfList.Items[1:] {
-		expectToEqual(t, g, item.Name, fmt.Sprintf("%s-pr-%d", original.Name, idx+1))
-		expectToEqual(t, g, item.Spec.SourceRef.Name, fmt.Sprintf("%s-source-pr-%d", original.Name, idx+1))
+	for _, item := range tfList.Items[1:] {
+		if item.Name == original.Name {
+			// Ignore the original source object.
+			continue
+		}
+		prID := item.Labels[bpconfig.LabelPRIDKey]
+		expectToEqual(t, g, item.Name, config.PullRequestObjectName(original.Name, prID))
+		expectToEqual(t, g, item.Spec.SourceRef.Name, config.SourceName(original.Name, source.Name, prID))
 		expectToEqual(t, g, item.Spec.SourceRef.Namespace, ns.Name)
 		expectToEqual(t, g, item.Spec.PlanOnly, true)
 		expectToEqual(t, g, item.Spec.StoreReadablePlan, "human")
@@ -203,7 +204,6 @@ func Test_poll_reconcile_objects(t *testing.T) {
 		g.Expect(item.Spec.WriteOutputsToSecret).To(gomega.BeNil()) // we don't need to use the output Secret of the plan
 		expectToEqual(t, g, item.Labels[bpconfig.LabelKey], bpconfig.LabelValue)
 		expectToEqual(t, g, item.Labels["test-label"], "abc")
-		expectToEqual(t, g, item.Labels[bpconfig.LabelPRIDKey], fmt.Sprint(idx+1))
 		expectToEqual(t, g, item.Spec.BackendConfig.SecretSuffix, original.Name)
 		expectToEqual(t, g, item.Spec.BackendConfig.InClusterConfig, true)
 	}
@@ -215,16 +215,17 @@ func Test_poll_reconcile_objects(t *testing.T) {
 	}))
 
 	expectToEqual(t, g, len(srcList.Items), 4)
-	// The first one is the original Source object.
-	expectToEqual(t, g, srcList.Items[0].Name, source.Name)
-
-	// Ignore the first one as it's the original resource.
-	for idx, item := range srcList.Items[1:] {
-		expectToEqual(t, g, item.Name, fmt.Sprintf("%s-pr-%d", source.Name, idx+1))
-		expectToEqual(t, g, item.Spec.Reference.Branch, fmt.Sprintf("test-branch-%d", idx+1))
+	for _, item := range srcList.Items {
+		if item.Name == source.Name {
+			// Ignore the original source object.
+			continue
+		}
+		prID := item.Labels[bpconfig.LabelPRIDKey]
+		expectToEqual(t, g, item.Name, config.SourceName(original.Name, source.Name, prID))
+		expectToEqual(t, g, item.Spec.Reference.Branch, "test-branch-"+prID)
 		expectToEqual(t, g, item.Labels[bpconfig.LabelKey], bpconfig.LabelValue)
+		expectToEqual(t, g, item.Labels[bpconfig.LabelPRIDKey], prID)
 		expectToEqual(t, g, item.Labels["test-label"], "123")
-		expectToEqual(t, g, item.Labels[bpconfig.LabelPRIDKey], fmt.Sprint(idx+1))
 	}
 
 	// Check that branch Terraform objects are updated
@@ -272,8 +273,13 @@ func Test_poll_reconcile_objects(t *testing.T) {
 	}))
 
 	expectToEqual(t, g, len(srcList.Items), 2)
-	expectToEqual(t, g, srcList.Items[0].Name, source.Name)
-	expectToEqual(t, g, srcList.Items[1].Name, source.Name+"-pr-3")
+	for _, item := range srcList.Items {
+		if item.Name == source.Name {
+			continue
+		}
+		// Only one item left and it should be PR#3.
+		expectToEqual(t, g, item.Name, config.SourceName(original.Name, source.Name, "3"))
+	}
 
 	t.Cleanup(func() { expectToSucceed(t, g, k8sClient.Delete(context.TODO(), ns)) })
 }

--- a/internal/server/polling/poll_test.go
+++ b/internal/server/polling/poll_test.go
@@ -188,7 +188,7 @@ func Test_poll_reconcile_objects(t *testing.T) {
 	}))
 
 	expectToEqual(t, g, len(tfList.Items), 4)
-	for _, item := range tfList.Items[1:] {
+	for _, item := range tfList.Items {
 		if item.Name == original.Name {
 			// Ignore the original source object.
 			continue


### PR DESCRIPTION
Issue
-----

When more than one Terraform resource points to the same git repository, when we clone the Source object, it does not create a new cloned Source object as the PullRequest ID is the same, the source name is the same, and we use only these two values to generate the name of the cloned resource.

Solution
--------
Add a short and deterministic hash to the name of the cloned Source object.

Another thoughts
----------------
It's not necessary to get a deterministic unique string, it could be random as we save the result as SourceRef. I decided to use a short (first 10 bytes of a sha256 hash), because if in the future we have to regenerate the values somehow, then we don't have to care about migration, extra compatibility checks. I know it's not likely we need this, but generating a random number
- doesn't yield shorter code.
- still doesn't guarantee it will not generate a conflicting name, and knowing computers, I think it's even more likely (still unlikely) to generate the same random value if the two generation happens (nearly) at the same time.

Additional changes
------------------
- Removed the hardcoded index-magic from poll_test. For some reasons it was not always in order. I don't know what changed tho.

Notes
----
Compatibility:
I was thinking about what happens with old resources, but after I spent some time on it, my conclusion is "they are not affected". We don't calculate names when we look up source objects for terraform objects. Their name is already saved as SourceRef. We generate this game only on newly created resources, therefore it does not break anything already in place.

Fixes #923

References:
- https://github.com/weaveworks/tf-controller/issues/923