### PR TITLE
chore: Only do security updates for Go modules and GH actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,12 @@ updates:
     directory: "/"
     labels: ["area/ci", "dependencies"]
     schedule:
-      interval: "daily"
+      interval: "weekly"
     # Project maintainers and the Wild Watermelon team
     reviewers:
-      - chanwit
       - "weaveworks/wild-watermelon"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0
     groups:
       # Group all updates together, so that they are all applied in a single PR.
       # Grouped updates are currently in beta and is subject to change.
@@ -17,3 +18,14 @@ updates:
       ci:
         patterns:
           - "*"
+
+
+  # maintain dependencies for github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "weaveworks/wild-watermelon"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Changed dependabot schedule to weekly as we don't have to bump dependencies straight away unless they are security fixes.