### PR TITLE
chore(deps): bump chart-testing-action to 2.6.1

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
Part of a separate, more complex, PR[^1] I already bumped because it's failing in this state. It wasn't an issue for a while, but now it's failing on another PR[^2] as they changed helm files.

The error:
```
INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v2.0.0'
Error: Process completed with exit code 1.
```

[^1]: https://github.com/weaveworks/tf-controller/pull/1061/files#diff-b3c960a8ea0195d6eab8b2a10935ad64f1164f20953b4cc93adeec970ee3dbaaR31
[^2]: https://github.com/weaveworks/tf-controller/pull/1099