### PR TITLE
Fix `make docker-build` target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ on:
 
 permissions:
   contents: read # for actions/checkout to fetch code
-  LIBCRYPTO_VERSION: "3.1.4-r1"
 
 env:
   CONTROLLER: ${{ github.event.repository.name }}
+  LIBCRYPTO_VERSION: "3.1.4-r1"
 
 jobs:
   build-push:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ SHELL = /usr/bin/env bash -o pipefail
 # Allows for defining additional Docker buildx arguments, e.g. '--push'.
 BUILD_ARGS ?=
 
+# Default architecture for terraform binary that gets bundled in runner images
+TERRAFORM_ARCH ?= amd64
+
 .PHONY: all
 all: build
 
@@ -146,11 +149,11 @@ run-planner: manifests generate fmt vet ## Run a branch planner from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker
-	docker build -t ${MANAGER_IMG}:${TAG} --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} ${BUILD_ARGS} .
-	docker build -t ${RUNNER_IMG}:${TAG}-base -f runner-base.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} ${BUILD_ARGS} .
-	docker build -t ${RUNNER_IMG}:${TAG} -f runner.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base ${BUILD_ARGS} .
-	docker build -t ${RUNNER_AZURE_IMAGE}:${TAG} -f runner-azure.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base ${BUILD_ARGS} .
-	docker build -t ${BRANCH_PLANNER_IMAGE}:${TAG} -f planner.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} ${BUILD_ARGS} .
+	docker build -t ${MANAGER_IMG}:${TAG} --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_IMG}:${TAG}-base -f runner-base.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_IMG}:${TAG} -f runner.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_AZURE_IMAGE}:${TAG} -f runner-azure.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
+	docker build -t ${BRANCH_PLANNER_IMAGE}:${TAG} -f planner.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
 
 .PHONY: docker-buildx
 docker-buildx: ## Build docker

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ SHELL = /usr/bin/env bash -o pipefail
 # Allows for defining additional Docker buildx arguments, e.g. '--push'.
 BUILD_ARGS ?=
 
-# Default architecture for terraform binary that gets bundled in runner images
-TERRAFORM_ARCH ?= amd64
+# Set architecture for the binaries we build as well as the terraform binary that get bundled in the images
+TARGETARCH ?= amd64
 
 .PHONY: all
 all: build
@@ -149,11 +149,11 @@ run-planner: manifests generate fmt vet ## Run a branch planner from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker
-	docker build -t ${MANAGER_IMG}:${TAG} --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
-	docker build -t ${RUNNER_IMG}:${TAG}-base -f runner-base.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
-	docker build -t ${RUNNER_IMG}:${TAG} -f runner.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
-	docker build -t ${RUNNER_AZURE_IMAGE}:${TAG} -f runner-azure.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
-	docker build -t ${BRANCH_PLANNER_IMAGE}:${TAG} -f planner.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TERRAFORM_ARCH} ${BUILD_ARGS} .
+	docker build -t ${MANAGER_IMG}:${TAG} --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TARGETARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_IMG}:${TAG}-base -f runner-base.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TARGETARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_IMG}:${TAG} -f runner.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TARGETARCH} ${BUILD_ARGS} .
+	docker build -t ${RUNNER_AZURE_IMAGE}:${TAG} -f runner-azure.Dockerfile --build-arg BASE_IMAGE=${RUNNER_IMG}:${TAG}-base --build-arg TARGETARCH=${TARGETARCH} ${BUILD_ARGS} .
+	docker build -t ${BRANCH_PLANNER_IMAGE}:${TAG} -f planner.Dockerfile --build-arg LIBCRYPTO_VERSION=${LIBCRYPTO_VERSION} --build-arg TARGETARCH=${TARGETARCH} ${BUILD_ARGS} .
 
 .PHONY: docker-buildx
 docker-buildx: ## Build docker


### PR DESCRIPTION
Fix `make docker-build` target as it was missing a TARGETARCH build argument. Note that this is only used in local dev, CI uses the official docker GitHub actions to build the images.
Also noticed that the env var for LIBCRYPTO_VERSION was misplaced.