### PR TITLE
chore: disable slack notifications about blocked issues

### DIFF
--- a/.github/workflows/blocked-reminder.yaml
+++ b/.github/workflows/blocked-reminder.yaml
@@ -1,10 +1,10 @@
 name: Wild Watermelon Blocked Issue Reminder on Slack
 on:
   workflow_dispatch:
-  schedule:
-    # Poke on Monday to kick off the week, and on Thu so we have time to poke
-    # others on Fri.
-    - cron: '0 15 * * 1,4'
+#  schedule:
+#    # Poke on Monday to kick off the week, and on Thu so we have time to poke
+#    # others on Fri.
+#    - cron: '0 15 * * 1,4'
 
 permissions:
   issues: read # for actions/github-script to query issues


### PR DESCRIPTION
The target Slack server will be shut down soon, this job will fail.

I leave it because we can enable it later to target other channels, the important part is to disable the cron job.

References:
- https://www.linkedin.com/posts/richardsonalexis_hi-everyone-i-am-very-sad-to-announce-activity-7160295096825860096-ZS67/