### PR TITLE
fix(branch-planner): prevent duplicate comments by checking plan rev

### DIFF
--- a/internal/informer/branch-planner/informer.go
+++ b/internal/informer/branch-planner/informer.go
@@ -307,12 +307,18 @@ func (i *Informer) isNewPlan(old, new *infrav1.Terraform) bool {
 		return false
 	}
 
+	if new.Status.LastPlannedRevision == "" {
+		return false
+	}
+
 	if old.Status.LastPlanAt == nil && new.Status.LastPlanAt != nil {
 		return true
 	}
 
 	if new.Status.LastPlanAt.After(old.Status.LastPlanAt.Time) {
-		return true
+		if old.Status.LastPlannedRevision != new.Status.LastPlannedRevision {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
While using github integration for branch-planner, I noticed that a comment with the plan was posted after each reconcilation of the plan (interval: 1m) even when no changes were made.

The branch planner was posting duplicate comments on pull requests because isNewPlan() only checked if the LastPlanAt timestamp changed, not whether the actual plan content (LastPlannedRevision) changed.

This caused the informer to repeatedly detect the same plan as "new" across reconciliation loops, triggering duplicate git provider comments for the same terraform plan.

Changes:
- Add early return if LastPlannedRevision is empty to avoid processing incomplete status updates
- Check both LastPlanAt timestamp AND LastPlannedRevision when determining if a plan is truly new
- Only post comments when the plan revision actually changes, not just the timestamp

This ensures comments are posted once per unique plan, preventing spam on pull requests during reconciliation loops.