### PR TITLE
docker: drop unused libretls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN apk update && \
   libcrypto3=${LIBCRYPTO_VERSION} \
   libssl3=${LIBCRYPTO_VERSION} \
   ca-certificates tini git openssh-client gnupg \
-  libretls \
   busybox
 
 COPY --from=builder /workspace/tofu-controller /usr/local/bin/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,6 @@ RUN apk update && \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \
     ca-certificates tini git openssh-client gnupg \
-    libretls \
     busybox
 
 COPY bin/tofu-controller /usr/local/bin/

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -46,7 +46,6 @@ RUN apk update && \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \
     ca-certificates tini git openssh-client gnupg \
-    libretls \
     busybox
 
 COPY --from=builder /workspace/branch-planner /usr/local/bin/

--- a/planner.Dockerfile.dev
+++ b/planner.Dockerfile.dev
@@ -9,7 +9,6 @@ RUN apk update && \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \
     ca-certificates tini git openssh-client gnupg \
-    libretls \
     busybox
 
 COPY bin/branch-planner /usr/local/bin/

--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -52,7 +52,6 @@ RUN apk update && \
     gnupg \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \
-    libretls \
     openssh-client \
     tini
 

--- a/runner.Dockerfile.dev
+++ b/runner.Dockerfile.dev
@@ -12,7 +12,6 @@ RUN apk update && \
     gnupg \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \
-    libretls \
     openssh-client \
     tini
 


### PR DESCRIPTION
In 8719a24ec6168ca61810cb0cc5c57049faf9a07b upgrade of libretls was
added because in alpine:3.15.1 libretls was installed by default in
alpine containers, as a depedency of apk-tools.

Note, that all of alpine tooling defaults to openssl, thus it is
curious that alpine:3.15 had such a dep, and one had to upgrade it to
fix a CVE.

In https://github.com/alpinelinux/aports/commit/d4d719c2657731a97f6bdf5a346ebfb8d1cc69a7 this dependency was corrected. Yet likely was still present somehow in the containers.

Note that alpine:3.16 does not have libretls by default. And I cannot
trace anything else ever using libretls. Note it is very strange to
install and require libssl3 (the openssl implementation) and libretls
(the libretls fork of openssl) at the same time.

Thus it seems to me the extra installation of libretls is an oversight
that was not dropped upon moving to alpine 3.16 base.

As far as I can tell libretls is innert and is unused, and to minimise
number of CVEs and packages in the containers, it is best to drop
explicit addition of it. As libssl should be sufficient for all use
cases.
