### PR TITLE
fix(ci): speed up docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,10 @@ COPY utils/ utils/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
-  go build -gcflags=all="-N -l" \
-  -ldflags "-X main.BuildSHA='${BUILD_SHA}' -X main.BuildVersion='${BUILD_VERSION}'" \
-  -a -o tofu-controller ./cmd/manager
+    go build \
+    -ldflags "-X main.BuildSHA=${BUILD_SHA} -X main.BuildVersion=${BUILD_VERSION}" \
+    -o tofu-controller \
+    ./cmd/manager
 
 FROM alpine:3.22
 

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -29,9 +29,7 @@ COPY internal internal
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build \
-    -gcflags=all="-N -l" \
     -ldflags "-X main.BuildSHA=${BUILD_SHA} -X main.BuildVersion=${BUILD_VERSION}" \
-    -a \
     -o branch-planner \
     ./cmd/branch-planner
 

--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -32,9 +32,7 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build \
-    -gcflags=all="-N -l" \
     -ldflags "-X main.BuildSHA=${BUILD_SHA} -X main.BuildVersion=${BUILD_VERSION}" \
-    -a \
     -o tf-runner \
     ./cmd/runner/main.go
 


### PR DESCRIPTION
This PR removes some additional flags from the Go build process, as they are only particularly useful for debug purposes.