### PR TITLE
chore(docs): update docs to refer to CNCF Slack Channel

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,7 +136,7 @@ Running the above will also deploy `source-controller` and its CRDs to the clust
 
 ## Communications
 
-For realtime communications we use Slack: To join the conversation, simply join the [Weave Users](https://weave-community.slack.com/) Slack workspace and use the [#tf-controller](https://weave-community.slack.com/messages/tf-controller/) channel.
+For realtime communications we use Slack: To join the conversation, simply join the [CNCF](https://slack.cncf.io/) Slack workspace and use the [#tofu-controller](https://cloud-native.slack.com/messages/tofu-controller) channel.
 
 To discuss ideas and specifications we use [Github Discussions](https://github.com/flux-iac/tofu-controller/discussions).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Tofu Controller offers many GitOps models:
 
 ## Get in touch
 
-If you have a feature request to share or a bug to report, please file an issue. You can also reach out via our [Tofu Controller Slack channel](https://weave-community.slack.com/archives/C054MR4UP88) — get there by first joining the [Weave Community Slack space](https://weave-community.slack.com).
+If you have a feature request to share or a bug to report, please file an issue.
+
+You can also reach out via our [Tofu Controller Slack channel](https://cloud-native.slack.com/messages/tofu-controller) — get there by first joining the [CNCF Slack space](https://slack.cncf.io/).
 
 ## Quickstart and documentation
 


### PR DESCRIPTION
Some users are unable to join the Weave Works Slack Workspace, so perhaps it makes a lot more sense to utilise the CNCF workspace for Slack.