### PR TITLE
fix(metrics): remove deprecated metrics

### DIFF
--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -152,8 +152,7 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			retErr = kerrors.NewAggregate([]error{retErr, err})
 		}
 
-		r.Metrics.RecordReadiness(ctx, terraform)
-		r.Metrics.RecordSuspend(ctx, terraform, terraform.Spec.Suspend)
+		// Record the duration of the reconciliation.
 		r.Metrics.RecordDuration(ctx, terraform, startTime)
 	}()
 


### PR DESCRIPTION
As per the main FluxCD controllers, we should no longer track the readiness and suspended metrics in the controller itself.

Instead, we should take advantage of `kube-state-metrics` which can do this for us with a little bit of extra configuration:

```yaml
kube-state-metrics:
  customResourceState:
    enabled: true
    config:
      spec:
        resources:
          - groupVersionKind:
              group: infra.contrib.fluxcd.io
              version: v1alpha2
              kind: Terraform
            metricNamePrefix: gotk
            metrics:
              - name: "resource_info"
                help: "The current state of a Flux Terraform resource."
                each:
                  type: Info
                  info:
                    labelsFromPath:
                      name: [metadata, name]
                labelsFromPath:
                  exported_namespace: [metadata, namespace]
                  ready: [status, conditions, "[type=Ready]", status]
                  suspended: [spec, suspend]
                  source_name: [spec, sourceRef, name]
```