### PR TITLE
fix: align tf-runner pod app.kubernetes.io/created-by label

### DIFF
--- a/controllers/tf_controller_runner.go
+++ b/controllers/tf_controller_runner.go
@@ -53,7 +53,7 @@ func runnerPodTemplate(terraform *infrav1.Terraform, secretName string, revision
 			Namespace: podNamespace,
 			Name:      podName,
 			Labels: map[string]string{
-				"app.kubernetes.io/created-by":   "tf-controller",
+				"app.kubernetes.io/created-by":   "tofu-controller",
 				"app.kubernetes.io/name":         "tf-runner",
 				"app.kubernetes.io/instance":     podInstance,
 				infrav1.RunnerLabel:              terraform.Namespace,

--- a/docs/use-tf-controller/with-tf-runner-exposed-using-hostname-subdomain.md
+++ b/docs/use-tf-controller/with-tf-runner-exposed-using-hostname-subdomain.md
@@ -42,7 +42,7 @@ spec:
   - name: grpc
     port: 30000
   selector:
-    app.kubernetes.io/created-by: tf-controller
+    app.kubernetes.io/created-by: tofu-controller
     app.kubernetes.io/name: tf-runner
 ```
 
@@ -52,7 +52,7 @@ spec:
 apiVersion: v1
 kind: Pod
   labels:
-    app.kubernetes.io/created-by: tf-controller
+    app.kubernetes.io/created-by: tofu-controller
     app.kubernetes.io/instance: tf-runner-3ac83e0f
     app.kubernetes.io/name: tf-runner
     infra.contrib.fluxcd.io/terraform: hello-world


### PR DESCRIPTION
Align the `app.kubernetes.io/created-by` label used for the TF Runner pod with the label used by the tf-runner Service.

Closes #1546