### PR TITLE
fix: reconcile terraform when reconcile.fluxcd.io/requestedAt is set

### DIFF
--- a/controllers/tf_controller.go
+++ b/controllers/tf_controller.go
@@ -561,6 +561,14 @@ func (r *TerraformReconciler) shouldReconcile(terraform *infrav1.Terraform) (boo
 		return true, 0
 	}
 
+	// Reconcile when a *new* reconcile request annotation is present
+	if requestedAt, ok := meta.ReconcileAnnotationValue(terraform.GetAnnotations()); ok {
+		// we do SetLastHandledReconcileRequest in the defer func, so check it here
+		if terraform.Status.GetLastHandledReconcileRequest() != requestedAt {
+			return true, 0
+		}
+	}
+
 	// If we have never planned, we should continue
 	if terraform.Status.LastPlanAt == nil {
 		return true, 0


### PR DESCRIPTION
In #1648 we added some additional logic to be smarter about when to handle reconciliations for Terraform resources, but didn't account for users updating the `reconcile.fluxcd.io/requestedAt` annotation to trigger a new reconciliation.

This PR checks whether the `reconcile.fluxcd.io/requestedAt` annotation is present and, if it is, checks whether the value is equal to the `LastHandledReconcileRequest` value - if they are different we trigger a reconciliation rather than skipping.

Closes #1660