### PR TITLE
fix(test): avoid race in test resources cleanup

### DIFF
--- a/controllers/tc000020_with_backend_no_outputs_test.go
+++ b/controllers/tc000020_with_backend_no_outputs_test.go
@@ -107,6 +107,8 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 		},
 	}
 	It("should be created and attached successfully.")
+	tfStateSecret := corev1.Secret{}
+	defer waitResourceToBeDelete(g, &tfStateSecret) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -184,7 +186,6 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 
 	By("checking that the TFSTATE secret are created in the same TF resource's namespace.")
 	tfStateKey := types.NamespacedName{Namespace: "flux-system", Name: "tfstate-default-" + terraformName}
-	tfStateSecret := corev1.Secret{}
 	g.Eventually(func() string {
 		err := k8sClient.Get(ctx, tfStateKey, &tfStateSecret)
 		if err != nil {
@@ -192,5 +193,4 @@ func Test_000020_with_backend_no_outputs_test(t *testing.T) {
 		}
 		return tfStateSecret.Name
 	}, timeout, interval).Should(Equal("tfstate-default-" + terraformName))
-	defer waitResourceToBeDelete(g, &tfStateSecret)
 }

--- a/controllers/tc000020_with_workspace_no_outputs_test.go
+++ b/controllers/tc000020_with_workspace_no_outputs_test.go
@@ -108,6 +108,8 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 		},
 	}
 	It("should be created and attached successfully.")
+	tfStateSecret := corev1.Secret{}
+	defer waitResourceToBeDelete(g, &tfStateSecret) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -185,7 +187,6 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 
 	By("checking that the TFSTATE secret are created in the same TF resource's namespace.")
 	tfStateKey := types.NamespacedName{Namespace: "flux-system", Name: "tfstate-custom-" + terraformName}
-	tfStateSecret := corev1.Secret{}
 	g.Eventually(func() string {
 		err := k8sClient.Get(ctx, tfStateKey, &tfStateSecret)
 		if err != nil {
@@ -193,5 +194,4 @@ func Test_000020_with_workspace_no_outputs_test(t *testing.T) {
 		}
 		return tfStateSecret.Name
 	}, timeout, interval).Should(Equal("tfstate-custom-" + terraformName))
-	defer waitResourceToBeDelete(g, &tfStateSecret)
 }

--- a/controllers/tc000030_plan_only_no_outputs_test.go
+++ b/controllers/tc000030_plan_only_no_outputs_test.go
@@ -98,6 +98,8 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 		},
 	}
 	It("should be created and attached successfully.")
+	tfplanSecret := corev1.Secret{}
+	defer waitResourceToBeDelete(g, &tfplanSecret) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -173,7 +175,6 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 	It("should generate the Secret containing the plan named with branch and commit id.")
 	By("checking that the Secret contains plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb in its labels.")
 	tfplanKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
-	tfplanSecret := corev1.Secret{}
 	g.Eventually(func() map[string]interface{} {
 		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
 		if err != nil {
@@ -189,5 +190,4 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
-	defer waitResourceToBeDelete(g, &tfplanSecret)
 }

--- a/controllers/tc000044_plan_only_mode_test.go
+++ b/controllers/tc000044_plan_only_mode_test.go
@@ -108,6 +108,8 @@ func Test_000044_plan_only_mode_test(t *testing.T) {
 		},
 	}
 	It("should be created and attached successfully.")
+	planOutput := corev1.ConfigMap{}
+	defer waitResourceToBeDelete(g, &planOutput) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -119,7 +121,6 @@ func Test_000044_plan_only_mode_test(t *testing.T) {
 	It("should be reconciled and produce the correct output secret.")
 	By("checking that the named output secret contains all outputs.")
 	outputKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
-	planOutput := corev1.ConfigMap{}
 	g.Eventually(func() (int, error) {
 		err := k8sClient.Get(ctx, outputKey, &planOutput)
 		if err != nil {
@@ -127,7 +128,6 @@ func Test_000044_plan_only_mode_test(t *testing.T) {
 		}
 		return len(planOutput.Data), nil
 	}, timeout, interval).Should(Equal(1))
-	defer waitResourceToBeDelete(g, &planOutput)
 
 	By("checking that the output ConfigMap contains the correct output data, provisioned by the TF resource.")
 

--- a/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
+++ b/controllers/tc000051_plan_and_manual_approve_and_replan_no_outputs_test.go
@@ -103,6 +103,8 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 		},
 	}
 	It("should be created and attached successfully.")
+	tfplanSecret := corev1.Secret{}
+	defer waitResourceToBeDelete(g, &tfplanSecret) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -178,7 +180,6 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 	By("checking that the planned secret is created.")
 	By("checking that the label of the planned secret is the $planId.")
 	tfplanKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
-	tfplanSecret := corev1.Secret{}
 	g.Eventually(func() map[string]interface{} {
 		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
 		if err != nil {
@@ -194,7 +195,6 @@ func Test_000051_plan_and_manual_approve_and_replan_no_outputs_test(t *testing.T
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
-	defer waitResourceToBeDelete(g, &tfplanSecret)
 
 	By("changing source to a new revision")
 	testRepo.Status = sourcev1.GitRepositoryStatus{

--- a/controllers/tc000052_plan_and_manual_approve_with_files_test.go
+++ b/controllers/tc000052_plan_and_manual_approve_with_files_test.go
@@ -127,6 +127,8 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 		},
 	}
 	It("should be created and attached successfully.")
+	tfplanSecret := corev1.Secret{}
+	defer waitResourceToBeDelete(g, &tfplanSecret) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -202,7 +204,6 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 	By("checking that the planned secret is created.")
 	By("checking that the label of the planned secret is the $planId.")
 	tfplanKey := types.NamespacedName{Namespace: "flux-system", Name: "tfplan-default-" + terraformName}
-	tfplanSecret := corev1.Secret{}
 	g.Eventually(func() map[string]interface{} {
 		err := k8sClient.Get(ctx, tfplanKey, &tfplanSecret)
 		if err != nil {
@@ -218,7 +219,6 @@ func Test_000052_plan_and_manual_approve_with_files_test(t *testing.T) {
 		"TFPlanEmpty":           false,
 		"HasEncodingAnnotation": true,
 	}))
-	defer waitResourceToBeDelete(g, &tfplanSecret)
 
 	time.Sleep(10 * time.Second)
 

--- a/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
+++ b/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
@@ -112,6 +112,9 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 			},
 		},
 	}
+
+	cmPayload := corev1.ConfigMap{}
+	defer waitResourceToBeDelete(g, &cmPayload) // must be deleted after TF resource
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
 	defer waitResourceToBeDelete(g, &helloWorldTF)
 
@@ -233,7 +236,6 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 	}
 
 	cmPayloadKey := types.NamespacedName{Namespace: "default", Name: "cm-" + terraformName}
-	var cmPayload corev1.ConfigMap
 	g.Eventually(func() string {
 		err := k8sClient.Get(ctx, cmPayloadKey, &cmPayload)
 		if err != nil {
@@ -241,7 +243,6 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 		}
 		return cmPayload.Name
 	}, timeout, interval).Should(Equal("cm-" + terraformName))
-	defer waitResourceToBeDelete(g, &cmPayload)
 
 	updatedTime = time.Now()
 	By("deleting configmap to create a drift")

--- a/controllers/tc000280_inventory_test.go
+++ b/controllers/tc000280_inventory_test.go
@@ -116,10 +116,10 @@ func Test_000280_inventory_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer waitResourceToBeDelete(g, &helloWorldTF)
 	defer waitResourceToBeDelete(g, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cm-" + terraformName},
-	})
+	}) // must be deleted after TF resource
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	It("should be created")
 	By("checking that the hello world TF got created")

--- a/controllers/tc000281_manifest_no_outputs_test.go
+++ b/controllers/tc000281_manifest_no_outputs_test.go
@@ -115,10 +115,10 @@ func Test_000281_manifest_no_outputs_test(t *testing.T) {
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, &helloWorldTF)).Should(Succeed())
-	defer waitResourceToBeDelete(g, &helloWorldTF)
 	defer waitResourceToBeDelete(g, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cm-" + terraformName},
-	})
+	}) // must be deleted after TF resource
+	defer waitResourceToBeDelete(g, &helloWorldTF)
 
 	It("should be created")
 	By("checking that the hello world TF got created")


### PR DESCRIPTION
In tests, delete resources created by Terraform resources after parent is deleted, otherwise there's a small chance for a race condition where Terraform may try to recreate resources after they were already deleted.
To achieve correct order, Terraform deletion must be deferred last, because defers are executed in reverse order.

NOTE: If test fails before object metadata is obtained, cleanup for that object will fail with "resource name may not be empty", but it will not prevent the rest of deferred cleanup, so it doesn't really affect anything.