### PR TITLE
fix(build): add missing build arguments for Go cross-compliation build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN groupadd -g 65532 controller \
     && useradd -u 65532 -g controller -r -s /sbin/nologin controller
 
 # Build the controller!
+ARG TARGETOS TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
     " \
     -X 'main.BuildSHA=${BUILD_SHA}' \

--- a/planner.Dockerfile
+++ b/planner.Dockerfile
@@ -20,6 +20,7 @@ RUN groupadd -g 65532 controller \
     && useradd -u 65532 -g controller -r -s /sbin/nologin controller
 
 # Build the controller!
+ARG TARGETOS TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
     " \
     -X 'main.BuildSHA=${BUILD_SHA}' \


### PR DESCRIPTION
I noticed that the latest build was failing to start on an ARM64 node, because we didn't include the required build arguments in the new Dockerfile.

```
exec /tofu-controller: exec format error
```