### PR TITLE
fix: avoid "secret already exists" error

### DIFF
--- a/controllers/tf_controller_runner.go
+++ b/controllers/tf_controller_runner.go
@@ -545,7 +545,7 @@ func (r *TerraformReconciler) reconcileRunnerSecret(ctx context.Context, terrafo
 			result.Secret.SetUID("")
 			result.Secret.SetGeneration(0)
 
-			if err := r.Client.Create(ctx, result.Secret); err != nil {
+			if err := r.Client.Create(ctx, result.Secret); err != nil && !errors.IsAlreadyExists(err) {
 				return nil, err
 			}
 		} else {


### PR DESCRIPTION
I sometimes observe the problem when doing manual reconcile with `tfctl reconcile` where controller would try to reconcile resource but fail to create the runner, and the logs would have an error:


> {"level":"error","ts":"2025-12-18T13:05:47.707Z","msg":"unable to lookup or create runner","controller":"terraform","controllerGroup":"infra.contrib.fluxcd.io","controllerKind":"Terraform","Terraform":{"name":"foo","namespace":"bar"},"namespace":"foo","name":"bar","reconcileID":"b96a2230-906b-4eaf-b50c-59504f0b1cf2","reconciliation-loop-id":"3ed08dbb-9be6-4c20-8725-ef0db523c929","start-time":"2025-12-18T13:05:47.446Z","error":"secrets \"terraform-runner.tls-1766667925\" already exists","stacktrace":"github.com/flux-iac/tofu-controller/controllers.(*TerraformReconciler).Reconcile\n\t/build/controllers/tf_controller.go:389\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296"}

When this happens, Terraform status transitions to reconciling, but no runner is created, and it gets stuck in this state until next reconcile.

After some digging, I discovered that it will first see that Secret does not exist [here](https://github.com/flux-iac/tofu-controller/blob/v0.16.0-rc.7/controllers/tf_controller_runner.go#L537), but then an attempt to create Secret [here](https://github.com/flux-iac/tofu-controller/blob/v0.16.0-rc.7/controllers/tf_controller_runner.go#L543) returns "resource already exists". Looks like a race. From what I gathered, TLS secrets can be created in two places: here and in mtls rotator. Why it's designed like this - I don't know, and I would be glad if someone explained it. I still don't fully understand why exactly race happens despite Ready channel reporting from rotator, but it seems that a simple check can avoid the problem.

 